### PR TITLE
Changed ColPack to v1.0.10 in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,18 +33,24 @@ cd $DIR/PACKAGES/ADOL-C
 cd $DIR
 
 # download ColPack
-wget -P PACKAGES http://cscapes.cs.purdue.edu/download/ColPack/ColPack-1.0.9.tar.gz
+#wget -P PACKAGES http://cscapes.cs.purdue.edu/download/ColPack/ColPack-1.0.9.tar.gz
+wget -P PACKAGES https://github.com/CSCsw/ColPack/archive/v1.0.10.zip
 
 # build ColPack
 cd $DIR/PACKAGES
-tar xfvz ColPack-1.0.9.tar.gz
-cd ColPack-1.0.9
+#tar xfvz ColPack-1.0.9.tar.gz
+#cd ColPack-1.0.9
+tar xfvz ColPack-1.0.10.tar.gz
+cd ColPack-1.0.10
 if [ SYSTEM = "x86_64" ]; then
+autoreconf -vif
 ./configure --prefix=`pwd`/../ADOL-C/ThirdParty/ColPack/ --libdir='${prefix}/lib64'
 else
+autoreconf -vif
 ./configure --prefix=`pwd`/../ADOL-C/ThirdParty/ColPack/ --libdir='${prefix}/lib'
 fi
-cd $DIR/PACKAGES/ColPack-1.0.9
+#cd $DIR/PACKAGES/ColPack-1.0.9
+cd $DIR/PACKAGES/ColPack-1.0.10
 make
 make install
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,13 +33,10 @@ cd $DIR/PACKAGES/ADOL-C
 cd $DIR
 
 # download ColPack
-#wget -P PACKAGES http://cscapes.cs.purdue.edu/download/ColPack/ColPack-1.0.9.tar.gz
-wget -P PACKAGES https://github.com/CSCsw/ColPack/archive/v1.0.10.zip
+wget -O PACKAGES/ColPack-1.0.10.tar.gz https://github.com/CSCsw/ColPack/archive/v1.0.10.tar.gz
 
 # build ColPack
 cd $DIR/PACKAGES
-#tar xfvz ColPack-1.0.9.tar.gz
-#cd ColPack-1.0.9
 tar xfvz ColPack-1.0.10.tar.gz
 cd ColPack-1.0.10
 if [ SYSTEM = "x86_64" ]; then
@@ -49,7 +46,6 @@ else
 autoreconf -vif
 ./configure --prefix=`pwd`/../ADOL-C/ThirdParty/ColPack/ --libdir='${prefix}/lib'
 fi
-#cd $DIR/PACKAGES/ColPack-1.0.9
 cd $DIR/PACKAGES/ColPack-1.0.10
 make
 make install


### PR DESCRIPTION
Building ColPack v1.0.9 fails with gcc 7.1.1, but v1.0.10 successfully builds with gcc 7.1.1 as well as some older versions (tested with 5.4.0).

Note that the newer ColPack from https://github.com/CSCsw/ColPack requires automake and autoconf.

(ref: https://github.com/b45ch1/pyadolc/issues/26)