### PR TITLE
support for current Boost and Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,10 +93,10 @@ INSTALLATION OSX:
         brew install automake
         brew install shtool
         brew install libtool
-        brew install boost@1.59
-        brew install boost-python@1.59
-        brew link boost@1.59 --force
-        brew link boost-python@1.59 --force
+        brew install boost
+        brew install boost-python
+        brew link boost --force
+        brew link boost-python --force
     
     * If you installed homebrew in the default location ``/usr/local``, you can skip this step.  Otherwise, if you installed homebrew somewhere else on your system, you will need to edit ``bootstrap.sh`` and ``setup.py``.  First, in the ColPack build section of ``bootstrap.sh``, add the flags::
         

--- a/adolc/__init__.py
+++ b/adolc/__init__.py
@@ -1,20 +1,20 @@
-import _adolc
-from _adolc import *
-from wrapped_functions import * 
-import cgraph
-import interpolation
+from . import _adolc
+from ._adolc import *
+from .wrapped_functions import * 
+from . import cgraph
+from . import interpolation
 
 try:
-    import sparse
+    from . import sparse
 except Exception as e:
-    print 'adolc Notice: sparse drivers not available'
-    print e
+    print('adolc Notice: sparse drivers not available')
+    print(e)
 try:
-    import colpack
+    from . import colpack
 
 except Exception as e:
-    print 'adolc Notice: colpack drivers not available'
-    print e
+    print('adolc Notice: colpack drivers not available')
+    print(e)
 
 # testing
 from numpy.testing import Tester

--- a/adolc/cgraph.py
+++ b/adolc/cgraph.py
@@ -1,7 +1,7 @@
 import copy
 import numpy
 import numpy.testing
-import wrapped_functions
+from . import wrapped_functions
 
 class AdolcProgram(object):
     def __init__(self):
@@ -94,7 +94,7 @@ class AdolcProgram(object):
                 try:
                     numpy.testing.assert_array_almost_equal(self.independentVariableShapeList[nV], V_shp[:-2])
                 except:
-                    raise ValueError('taped independentVariableShapeList = %s\n but supplied Vs = %s'%(str(self.independentVariableShapeList), str(map(numpy.shape, Vs))))
+                    raise ValueError('taped independentVariableShapeList = %s\n but supplied Vs = %s'%(str(self.independentVariableShapeList), str(list(map(numpy.shape, Vs)))))
                 rV_list.append(numpy.reshape(V, (numpy.prod(V_shp[:-2]),) + V_shp[-2:]))
             self.V = numpy.ascontiguousarray(numpy.concatenate(rV_list,axis=0))
             

--- a/adolc/colpack/__init__.py
+++ b/adolc/colpack/__init__.py
@@ -1,1 +1,1 @@
-from wrapped_functions import * 
+from .wrapped_functions import * 

--- a/adolc/colpack/src/num_util.cpp
+++ b/adolc/colpack/src/num_util.cpp
@@ -182,47 +182,47 @@ static KindTypeMap kindtypes(kindTypeMapEntries,
                                    kindTypeMapEntries + numTypeEntries);
 
 //Create a numarray referencing Python sequence object
-numeric::array makeNum(object x){
+numpy::ndarray makeNum(object x){
   if (!PySequence_Check(x.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a sequence");
     throw_error_already_set();
   }
   object obj(handle<>
-       (PyArray_ContiguousFromObject(x.ptr(),NPY_NOTYPE,0,0)));
+	     (PyArray_ContiguousFromObject(x.ptr(),NPY_NOTYPE,0,0)));
   check_PyArrayElementType(obj);
-  return extract<numeric::array>(obj); 
+  return extract<numpy::ndarray>(obj); 
 }
 
 //Create a one-dimensional Numeric array of length n and Numeric type t
-numeric::array makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
+numpy::ndarray makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(1, &n, t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
   
 //Create a Numeric array with dimensions dimens and Numeric type t
-numeric::array makeNum(std::vector<npy_intp> dimens, 
-           NPY_TYPES t=NPY_DOUBLE){
+numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
+		       NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(dimens.size(), &dimens[0], t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
 
-numeric::array makeNum(const numeric::array& arr){
-  //Returns a reference of arr by calling numeric::array copy constructor.
+numpy::ndarray makeNum(const numpy::ndarray& arr){
+  //Returns a reference of arr by calling numpy::ndarray copy constructor.
   //The copy constructor increases arr's reference count.
-  return numeric::array(arr);
+  return numpy::ndarray(arr);
 } 
 
-NPY_TYPES type(numeric::array arr){
+NPY_TYPES type(numpy::ndarray arr){
   return NPY_TYPES(PyArray_TYPE(reinterpret_cast<PyArrayObject*>(arr.ptr())));
 }
 
-void check_type(boost::python::numeric::array arr, 
-    NPY_TYPES expected_type){
+void check_type(boost::python::numpy::ndarray arr, 
+		NPY_TYPES expected_type){
   NPY_TYPES actual_type = type(arr);
   if (actual_type != expected_type) {
     std::ostringstream stream;
     stream << "expected Numeric type " << kindstrings[expected_type]
-     << ", found Numeric type " << kindstrings[actual_type] << std::ends;
+	   << ", found Numeric type " << kindstrings[actual_type] << std::ends;
     PyErr_SetString(PyExc_TypeError, stream.str().c_str());
     throw_error_already_set();
   }
@@ -230,7 +230,7 @@ void check_type(boost::python::numeric::array arr,
 }
 
 //Return the number of dimensions
-int rank(numeric::array arr){
+int rank(numpy::ndarray arr){
   //std::cout << "inside rank" << std::endl;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -239,19 +239,19 @@ int rank(numeric::array arr){
   return PyArray_NDIM(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_rank(boost::python::numeric::array arr, int expected_rank){
+void check_rank(boost::python::numpy::ndarray arr, int expected_rank){
   int actual_rank = rank(arr);
   if (actual_rank != expected_rank) {
     std::ostringstream stream;
     stream << "expected rank " << expected_rank 
-     << ", found rank " << actual_rank << std::ends;
+	   << ", found rank " << actual_rank << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-npy_intp size(numeric::array arr)
+npy_intp size(numpy::ndarray arr)
 {
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -260,19 +260,19 @@ npy_intp size(numeric::array arr)
   return PyArray_Size(arr.ptr());
 }
 
-void check_size(boost::python::numeric::array arr, npy_intp expected_size){
+void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size){
   npy_intp actual_size = size(arr);
   if (actual_size != expected_size) {
     std::ostringstream stream;
     stream << "expected size " << expected_size 
-     << ", found size " << actual_size << std::ends;
+	   << ", found size " << actual_size << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-std::vector<npy_intp> shape(numeric::array arr){
+std::vector<npy_intp> shape(numpy::ndarray arr){
   std::vector<npy_intp> out_dims;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -286,7 +286,7 @@ std::vector<npy_intp> shape(numeric::array arr){
   return out_dims;
 }
 
-npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
+npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum){
   assert(dimnum >= 0);
   int the_rank=rank(arr);
   if(the_rank < dimnum){
@@ -300,19 +300,19 @@ npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
   return actual_dims[dimnum];
 }
 
-void check_shape(boost::python::numeric::array arr, std::vector<npy_intp> expected_dims){
+void check_shape(boost::python::numpy::ndarray arr, std::vector<npy_intp> expected_dims){
   std::vector<npy_intp> actual_dims = shape(arr);
   if (actual_dims != expected_dims) {
     std::ostringstream stream;
     stream << "expected dimensions " << vector_str(expected_dims)
-     << ", found dimensions " << vector_str(actual_dims) << std::ends;
+	   << ", found dimensions " << vector_str(actual_dims) << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
+void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize){
   std::vector<npy_intp> actual_dims = shape(arr);
   if(actual_dims[dimnum] != dimsize){
     std::ostringstream stream;
@@ -325,13 +325,13 @@ void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
   return;
 }
 
-bool iscontiguous(numeric::array arr)
+bool iscontiguous(numpy::ndarray arr)
 {
   //  return arr.iscontiguous();
   return PyArray_ISCONTIGUOUS(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_contiguous(numeric::array arr)
+void check_contiguous(numpy::ndarray arr)
 {
   if (!iscontiguous(arr)) {
     PyErr_SetString(PyExc_RuntimeError, "expected a contiguous array");
@@ -340,7 +340,7 @@ void check_contiguous(numeric::array arr)
   return;
 }
 
-void* data(numeric::array arr){
+void* data(numpy::ndarray arr){
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
     throw_error_already_set();
@@ -349,7 +349,7 @@ void* data(numeric::array arr){
 }
 
 //Copy data into the array
-void copy_data(boost::python::numeric::array arr, char* new_data){
+void copy_data(boost::python::numpy::ndarray arr, char* new_data){
   char* arr_data = (char*) data(arr);
   npy_intp nbytes = PyArray_NBYTES(reinterpret_cast<PyArrayObject*>(arr.ptr()));
   for (npy_intp i = 0; i < nbytes; i++) {
@@ -359,18 +359,18 @@ void copy_data(boost::python::numeric::array arr, char* new_data){
 } 
 
 //Return a clone of this array
-numeric::array clone(numeric::array arr){
+numpy::ndarray clone(numpy::ndarray arr){
   object obj(handle<>(PyArray_NewCopy(reinterpret_cast<PyArrayObject*>(arr.ptr()),NPY_CORDER)));
   return makeNum(obj);
 }
 
   
 //Return a clone of this array with a new type
-numeric::array astype(boost::python::numeric::array arr, NPY_TYPES t){
-  return (numeric::array) arr.astype(type2char(t));
+numpy::ndarray astype(boost::python::numpy::ndarray arr, NPY_TYPES t){
+  return (numpy::ndarray) arr.astype(boost::python::numpy::dtype(boost::python::str(type2char(t))));
 }
 
-std::vector<npy_intp> strides(numeric::array arr){
+std::vector<npy_intp> strides(numpy::ndarray arr){
   std::vector<npy_intp> out_strides;
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -384,7 +384,7 @@ std::vector<npy_intp> strides(numeric::array arr){
   return out_strides;
 }
 
-int refcount(numeric::array arr){
+int refcount(numpy::ndarray arr){
   return REFCOUNT(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
@@ -394,7 +394,7 @@ void check_PyArrayElementType(object newo){
       std::ostringstream stream;
       stream << "array elments have been cast to NPY_OBJECT, "
              << "numhandle can only accept arrays with numerical elements" 
-       << std::ends;
+	     << std::ends;
       PyErr_SetString(PyExc_TypeError, stream.str().c_str());
       throw_error_already_set();
   }

--- a/adolc/colpack/src/num_util.h
+++ b/adolc/colpack/src/num_util.h
@@ -12,6 +12,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
 #include <numpy/noprefix.h>
 #include <iostream>
 #include <sstream>
@@ -29,7 +30,7 @@ namespace num_util{
    *@param x a sequential PyObject wrapped in a Boost/Python 'object'.
    *@return a PyArrayObject wrapped in Boost/Python numeric array.
    */
-  boost::python::numeric::array makeNum(boost::python::object x);
+  boost::python::numpy::ndarray makeNum(boost::python::object x);
 
   /** 
    *Creates an one-dimensional numpy array of length n and numpy type t. 
@@ -38,7 +39,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of size n with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(npy_intp n, NPY_TYPES t);
+  boost::python::numpy::ndarray makeNum(npy_intp n, NPY_TYPES t);
 
   /** 
    *Creates a n-dimensional numpy array with dimensions dimens and numpy 
@@ -47,9 +48,9 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of shape dimens with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(std::vector<npy_intp> dimens, 
-          NPY_TYPES t);
-              
+  boost::python::numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
+					NPY_TYPES t);
+				      
   /** 
    *Function template returns PyArray_Type for C++ type
    *See num_util.cpp for specializations
@@ -73,11 +74,11 @@ namespace num_util{
    *@return a numpy array of size n with elements initialized to data.
    */
 
-  template <typename T> boost::python::numeric::array makeNum(T* data, npy_intp n = 0){
+  template <typename T> boost::python::numpy::ndarray makeNum(T* data, npy_intp n = 0){
     boost::python::object obj(boost::python::handle<>((PyArray_SimpleNew(1, &n, getEnum<T>()))));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * n); // copies the input data to 
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
 
   /** 
@@ -90,12 +91,12 @@ namespace num_util{
    */
 
 
-  template <typename T> boost::python::numeric::array makeNum(T * data, std::vector<npy_intp> dims){
+  template <typename T> boost::python::numpy::ndarray makeNum(T * data, std::vector<npy_intp> dims){
     npy_intp total = std::accumulate(dims.begin(),dims.end(),1,std::multiplies<npy_intp>());
     boost::python::object obj(boost::python::handle<>(PyArray_SimpleNew(dims.size(),&dims[0], getEnum<T>())));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * total);
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
     
 
@@ -104,15 +105,15 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return a numeric array referencing the input array.
    */
-  boost::python::numeric::array makeNum(const 
-          boost::python::numeric::array& arr);
+  boost::python::numpy::ndarray makeNum(const 
+					boost::python::numpy::ndarray& arr);
 
   /** 
    *A free function that retrieves the numpy type of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return the numpy type of the array's elements 
    */
-  NPY_TYPES type(boost::python::numeric::array arr);
+  NPY_TYPES type(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual array type is not equal to the expected 
@@ -121,15 +122,15 @@ namespace num_util{
    *@param expected_type an expected numpy type.
    *@return -----
    */
-  void check_type(boost::python::numeric::array arr, 
-      NPY_TYPES expected_type);
+  void check_type(boost::python::numpy::ndarray arr, 
+		  NPY_TYPES expected_type);
 
   /** 
    *A free function that retrieves the number of dimensions of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the rank of an array.
    */
-  int rank(boost::python::numeric::array arr);
+  int rank(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual rank is not equal to the expected rank.
@@ -137,14 +138,14 @@ namespace num_util{
    *@param expected_rank an expected rank of the numeric array.
    *@return -----
    */
-  void check_rank(boost::python::numeric::array arr, int expected_rank);
+  void check_rank(boost::python::numpy::ndarray arr, int expected_rank);
   
   /** 
    *A free function that returns the total size of the array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the total size of the array.
    */
-  npy_intp size(boost::python::numeric::array arr);
+  npy_intp size(boost::python::numpy::ndarray arr);
   
   /** 
    *Throw an exception if the actual total size of the array is not equal to 
@@ -153,14 +154,14 @@ namespace num_util{
    *@param expected_size the expected size of an array.
    *@return -----
    */
-  void check_size(boost::python::numeric::array arr, npy_intp expected_size);
+  void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size);
 
   /** 
    *Returns the dimensions in a vector.
    *@param arr a Boost/Python numeric array.
    *@return a vector with integer values that indicates the shape of the array.
   */
-  std::vector<npy_intp> shape(boost::python::numeric::array arr);
+  std::vector<npy_intp> shape(boost::python::numpy::ndarray arr);
 
   /**
    *Returns the size of a specific dimension.
@@ -168,7 +169,7 @@ namespace num_util{
    *@param dimnum an integer that identifies the dimension to retrieve.
    *@return the size of the requested dimension.
    */
-  npy_intp get_dim(boost::python::numeric::array arr, int dimnum);
+  npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum);
 
   /** 
    *Throws an exception if the actual dimensions of the array are not equal to
@@ -177,8 +178,8 @@ namespace num_util{
    *@param expected_dims an integer vector of expected dimension.
    *@return -----
    */
-  void check_shape(boost::python::numeric::array arr, 
-       std::vector<npy_intp> expected_dims);
+  void check_shape(boost::python::numpy::ndarray arr, 
+		   std::vector<npy_intp> expected_dims);
 
   /**
    *Throws an exception if a specific dimension from a numpy array does not
@@ -188,28 +189,28 @@ namespace num_util{
    *@param dimsize an expected size of the specified dimension.
    *@return -----
   */
-  void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize);
+  void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize);
 
   /** 
    *Returns true if the array is contiguous.
    *@param arr a Boost/Python numeric array.
    *@return true if the array is contiguous, false otherwise.
   */
-  bool iscontiguous(boost::python::numeric::array arr);
+  bool iscontiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the array is not contiguous.
    *@param arr a Boost/Python numeric array.
    *@return -----
   */
-  void check_contiguous(boost::python::numeric::array arr);
+  void check_contiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns a pointer to the data in the array.
    *@param arr a Boost/Python numeric array.
    *@return a char pointer pointing at the first element of the array.
    */
-  void* data(boost::python::numeric::array arr);
+  void* data(boost::python::numpy::ndarray arr);
 
   /** 
    *Copies data into the array.
@@ -217,14 +218,14 @@ namespace num_util{
    *@param new_data a char pointer referencing the new data.
    *@return -----
    */
-  void copy_data(boost::python::numeric::array arr, char* new_data);
+  void copy_data(boost::python::numpy::ndarray arr, char* new_data);
   
   /** 
    *Returns a clone of this array.
    *@param arr a Boost/Python numeric array.
    *@return a replicate of the Boost/Python numeric array.
    */
-  boost::python::numeric::array clone(boost::python::numeric::array arr);
+  boost::python::numpy::ndarray clone(boost::python::numpy::ndarray arr);
   
   /** 
    *Returns a clone of this array with a new type.
@@ -232,22 +233,22 @@ namespace num_util{
    *@param t NPY_TYPES of the output array.
    *@return a replicate of 'arr' with type set to 't'.
    */
-  boost::python::numeric::array astype(boost::python::numeric::array arr, 
-               NPY_TYPES t);
+  boost::python::numpy::ndarray astype(boost::python::numpy::ndarray arr, 
+				       NPY_TYPES t);
 
 
 /*    *Returns the reference count of the array. */
 /*    *@param arr a Boost/Python numeric array. */
 /*    *@return the reference count of the array. */
 
-  int refcount(boost::python::numeric::array arr);
+  int refcount(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns the strides array in a vector of integer.
    *@param arr a Boost/Python numeric array.
    *@return the strides of an array.
    */
-  std::vector<npy_intp> strides(boost::python::numeric::array arr);
+  std::vector<npy_intp> strides(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the element of a numpy array is type cast to

--- a/adolc/colpack/src/py_colpack_adolc.cpp
+++ b/adolc/colpack/src/py_colpack_adolc.cpp
@@ -1,6 +1,6 @@
 #include "py_colpack_adolc.hpp"
 
-bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options){
+bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -22,9 +22,9 @@ bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::ar
 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_INT, (char*) cind )));
 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_DOUBLE, (char*) values )));
 
-	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 	bp::list retvals;
 	retvals.append(ret_nnz);
@@ -36,7 +36,7 @@ bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::ar
 
 }
 
-bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values){
+bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -62,7 +62,7 @@ bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::array &bpn_x, npy_intp n
 }
 
 
-bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options){
+bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -82,9 +82,9 @@ bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::a
 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_UINT, (char*) cind )));
 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_DOUBLE, (char*) values )));
 
-	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 	bp::list retvals;
 	retvals.append(ret_nnz);
@@ -96,7 +96,7 @@ bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::a
 
 }
 
-bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values){
+bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	npy_intp N = tape_stats[NUM_INDEPENDENTS];

--- a/adolc/colpack/src/py_colpack_adolc.hpp
+++ b/adolc/colpack/src/py_colpack_adolc.hpp
@@ -10,7 +10,7 @@
 using namespace std;
 namespace b = boost;
 namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
+namespace bpn = boost::python::numpy;
 namespace nu = num_util;
 
 // extern int jac_pat(short,int,int,double*,unsigned int**,int*);
@@ -21,17 +21,19 @@ namespace nu = num_util;
 // extern int sparse_hess(short, int , int, double*, int *, unsigned int **, unsigned int **, double **,int*);
 // extern int bit_vector_propagation(short, int, int, double*, unsigned int**, int*);
 
-bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options);
-bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values);
+bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options);
+bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values);
 
-bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options);
-bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values);
+bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options);
+bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values);
+
+#define NUMPY_IMPORT_ARRAY_RETVAL
 
 BOOST_PYTHON_MODULE(_colpack)
 {
 	using namespace boost::python;
-	import_array(); 										/* some kind of hack to get numpy working */
-	bpn::array::set_module_and_type("numpy", "ndarray");	/* some kind of hack to get numpy working */
+  bpn::initialize();
+  import_array();
 	def("sparse_jac_no_repeat",  &wrapped_sparse_jac_no_repeat);
 	def("sparse_jac_repeat",  &wrapped_sparse_jac_repeat);
 

--- a/adolc/colpack/tests/test_wrapped_functions.py
+++ b/adolc/colpack/tests/test_wrapped_functions.py
@@ -374,6 +374,6 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()
 

--- a/adolc/colpack/wrapped_functions.py
+++ b/adolc/colpack/wrapped_functions.py
@@ -1,5 +1,5 @@
-import _colpack
-from _colpack import *
+from . import _colpack
+from ._colpack import *
 
 import numpy
 

--- a/adolc/sparse/__init__.py
+++ b/adolc/sparse/__init__.py
@@ -1,1 +1,1 @@
-from wrapped_functions import *
+from .wrapped_functions import *

--- a/adolc/sparse/src/num_util.cpp
+++ b/adolc/sparse/src/num_util.cpp
@@ -182,47 +182,47 @@ static KindTypeMap kindtypes(kindTypeMapEntries,
                                    kindTypeMapEntries + numTypeEntries);
 
 //Create a numarray referencing Python sequence object
-numeric::array makeNum(object x){
+numpy::ndarray makeNum(object x){
   if (!PySequence_Check(x.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a sequence");
     throw_error_already_set();
   }
   object obj(handle<>
-       (PyArray_ContiguousFromObject(x.ptr(),NPY_NOTYPE,0,0)));
+	     (PyArray_ContiguousFromObject(x.ptr(),NPY_NOTYPE,0,0)));
   check_PyArrayElementType(obj);
-  return extract<numeric::array>(obj); 
+  return extract<numpy::ndarray>(obj); 
 }
 
 //Create a one-dimensional Numeric array of length n and Numeric type t
-numeric::array makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
+numpy::ndarray makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(1, &n, t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
   
 //Create a Numeric array with dimensions dimens and Numeric type t
-numeric::array makeNum(std::vector<npy_intp> dimens, 
-           NPY_TYPES t=NPY_DOUBLE){
+numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
+		       NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(dimens.size(), &dimens[0], t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
 
-numeric::array makeNum(const numeric::array& arr){
-  //Returns a reference of arr by calling numeric::array copy constructor.
+numpy::ndarray makeNum(const numpy::ndarray& arr){
+  //Returns a reference of arr by calling numpy::ndarray copy constructor.
   //The copy constructor increases arr's reference count.
-  return numeric::array(arr);
+  return numpy::ndarray(arr);
 } 
 
-NPY_TYPES type(numeric::array arr){
+NPY_TYPES type(numpy::ndarray arr){
   return NPY_TYPES(PyArray_TYPE(reinterpret_cast<PyArrayObject*>(arr.ptr())));
 }
 
-void check_type(boost::python::numeric::array arr, 
-    NPY_TYPES expected_type){
+void check_type(boost::python::numpy::ndarray arr, 
+		NPY_TYPES expected_type){
   NPY_TYPES actual_type = type(arr);
   if (actual_type != expected_type) {
     std::ostringstream stream;
     stream << "expected Numeric type " << kindstrings[expected_type]
-     << ", found Numeric type " << kindstrings[actual_type] << std::ends;
+	   << ", found Numeric type " << kindstrings[actual_type] << std::ends;
     PyErr_SetString(PyExc_TypeError, stream.str().c_str());
     throw_error_already_set();
   }
@@ -230,7 +230,7 @@ void check_type(boost::python::numeric::array arr,
 }
 
 //Return the number of dimensions
-int rank(numeric::array arr){
+int rank(numpy::ndarray arr){
   //std::cout << "inside rank" << std::endl;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -239,19 +239,19 @@ int rank(numeric::array arr){
   return PyArray_NDIM(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_rank(boost::python::numeric::array arr, int expected_rank){
+void check_rank(boost::python::numpy::ndarray arr, int expected_rank){
   int actual_rank = rank(arr);
   if (actual_rank != expected_rank) {
     std::ostringstream stream;
     stream << "expected rank " << expected_rank 
-     << ", found rank " << actual_rank << std::ends;
+	   << ", found rank " << actual_rank << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-npy_intp size(numeric::array arr)
+npy_intp size(numpy::ndarray arr)
 {
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -260,19 +260,19 @@ npy_intp size(numeric::array arr)
   return PyArray_Size(arr.ptr());
 }
 
-void check_size(boost::python::numeric::array arr, npy_intp expected_size){
+void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size){
   npy_intp actual_size = size(arr);
   if (actual_size != expected_size) {
     std::ostringstream stream;
     stream << "expected size " << expected_size 
-     << ", found size " << actual_size << std::ends;
+	   << ", found size " << actual_size << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-std::vector<npy_intp> shape(numeric::array arr){
+std::vector<npy_intp> shape(numpy::ndarray arr){
   std::vector<npy_intp> out_dims;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -286,7 +286,7 @@ std::vector<npy_intp> shape(numeric::array arr){
   return out_dims;
 }
 
-npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
+npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum){
   assert(dimnum >= 0);
   int the_rank=rank(arr);
   if(the_rank < dimnum){
@@ -300,19 +300,19 @@ npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
   return actual_dims[dimnum];
 }
 
-void check_shape(boost::python::numeric::array arr, std::vector<npy_intp> expected_dims){
+void check_shape(boost::python::numpy::ndarray arr, std::vector<npy_intp> expected_dims){
   std::vector<npy_intp> actual_dims = shape(arr);
   if (actual_dims != expected_dims) {
     std::ostringstream stream;
     stream << "expected dimensions " << vector_str(expected_dims)
-     << ", found dimensions " << vector_str(actual_dims) << std::ends;
+	   << ", found dimensions " << vector_str(actual_dims) << std::ends;
     PyErr_SetString(PyExc_RuntimeError, stream.str().c_str());
     throw_error_already_set();
   }
   return;
 }
 
-void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
+void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize){
   std::vector<npy_intp> actual_dims = shape(arr);
   if(actual_dims[dimnum] != dimsize){
     std::ostringstream stream;
@@ -325,13 +325,13 @@ void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
   return;
 }
 
-bool iscontiguous(numeric::array arr)
+bool iscontiguous(numpy::ndarray arr)
 {
   //  return arr.iscontiguous();
   return PyArray_ISCONTIGUOUS(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_contiguous(numeric::array arr)
+void check_contiguous(numpy::ndarray arr)
 {
   if (!iscontiguous(arr)) {
     PyErr_SetString(PyExc_RuntimeError, "expected a contiguous array");
@@ -340,7 +340,7 @@ void check_contiguous(numeric::array arr)
   return;
 }
 
-void* data(numeric::array arr){
+void* data(numpy::ndarray arr){
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
     throw_error_already_set();
@@ -349,7 +349,7 @@ void* data(numeric::array arr){
 }
 
 //Copy data into the array
-void copy_data(boost::python::numeric::array arr, char* new_data){
+void copy_data(boost::python::numpy::ndarray arr, char* new_data){
   char* arr_data = (char*) data(arr);
   npy_intp nbytes = PyArray_NBYTES(reinterpret_cast<PyArrayObject*>(arr.ptr()));
   for (npy_intp i = 0; i < nbytes; i++) {
@@ -359,18 +359,18 @@ void copy_data(boost::python::numeric::array arr, char* new_data){
 } 
 
 //Return a clone of this array
-numeric::array clone(numeric::array arr){
+numpy::ndarray clone(numpy::ndarray arr){
   object obj(handle<>(PyArray_NewCopy(reinterpret_cast<PyArrayObject*>(arr.ptr()),NPY_CORDER)));
   return makeNum(obj);
 }
 
   
 //Return a clone of this array with a new type
-numeric::array astype(boost::python::numeric::array arr, NPY_TYPES t){
-  return (numeric::array) arr.astype(type2char(t));
+numpy::ndarray astype(boost::python::numpy::ndarray arr, NPY_TYPES t){
+  return (numpy::ndarray) arr.astype(boost::python::numpy::dtype(boost::python::str(type2char(t))));
 }
 
-std::vector<npy_intp> strides(numeric::array arr){
+std::vector<npy_intp> strides(numpy::ndarray arr){
   std::vector<npy_intp> out_strides;
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -384,7 +384,7 @@ std::vector<npy_intp> strides(numeric::array arr){
   return out_strides;
 }
 
-int refcount(numeric::array arr){
+int refcount(numpy::ndarray arr){
   return REFCOUNT(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
@@ -394,7 +394,7 @@ void check_PyArrayElementType(object newo){
       std::ostringstream stream;
       stream << "array elments have been cast to NPY_OBJECT, "
              << "numhandle can only accept arrays with numerical elements" 
-       << std::ends;
+	     << std::ends;
       PyErr_SetString(PyExc_TypeError, stream.str().c_str());
       throw_error_already_set();
   }

--- a/adolc/sparse/src/num_util.h
+++ b/adolc/sparse/src/num_util.h
@@ -12,6 +12,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
 #include <numpy/noprefix.h>
 #include <iostream>
 #include <sstream>
@@ -29,7 +30,7 @@ namespace num_util{
    *@param x a sequential PyObject wrapped in a Boost/Python 'object'.
    *@return a PyArrayObject wrapped in Boost/Python numeric array.
    */
-  boost::python::numeric::array makeNum(boost::python::object x);
+  boost::python::numpy::ndarray makeNum(boost::python::object x);
 
   /** 
    *Creates an one-dimensional numpy array of length n and numpy type t. 
@@ -38,7 +39,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of size n with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(npy_intp n, NPY_TYPES t);
+  boost::python::numpy::ndarray makeNum(npy_intp n, NPY_TYPES t);
 
   /** 
    *Creates a n-dimensional numpy array with dimensions dimens and numpy 
@@ -47,9 +48,9 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of shape dimens with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(std::vector<npy_intp> dimens, 
-          NPY_TYPES t);
-              
+  boost::python::numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
+					NPY_TYPES t);
+				      
   /** 
    *Function template returns PyArray_Type for C++ type
    *See num_util.cpp for specializations
@@ -73,11 +74,11 @@ namespace num_util{
    *@return a numpy array of size n with elements initialized to data.
    */
 
-  template <typename T> boost::python::numeric::array makeNum(T* data, npy_intp n = 0){
+  template <typename T> boost::python::numpy::ndarray makeNum(T* data, npy_intp n = 0){
     boost::python::object obj(boost::python::handle<>((PyArray_SimpleNew(1, &n, getEnum<T>()))));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * n); // copies the input data to 
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
 
   /** 
@@ -90,12 +91,12 @@ namespace num_util{
    */
 
 
-  template <typename T> boost::python::numeric::array makeNum(T * data, std::vector<npy_intp> dims){
+  template <typename T> boost::python::numpy::ndarray makeNum(T * data, std::vector<npy_intp> dims){
     npy_intp total = std::accumulate(dims.begin(),dims.end(),1,std::multiplies<npy_intp>());
     boost::python::object obj(boost::python::handle<>(PyArray_SimpleNew(dims.size(),&dims[0], getEnum<T>())));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * total);
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
     
 
@@ -104,15 +105,15 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return a numeric array referencing the input array.
    */
-  boost::python::numeric::array makeNum(const 
-          boost::python::numeric::array& arr);
+  boost::python::numpy::ndarray makeNum(const 
+					boost::python::numpy::ndarray& arr);
 
   /** 
    *A free function that retrieves the numpy type of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return the numpy type of the array's elements 
    */
-  NPY_TYPES type(boost::python::numeric::array arr);
+  NPY_TYPES type(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual array type is not equal to the expected 
@@ -121,15 +122,15 @@ namespace num_util{
    *@param expected_type an expected numpy type.
    *@return -----
    */
-  void check_type(boost::python::numeric::array arr, 
-      NPY_TYPES expected_type);
+  void check_type(boost::python::numpy::ndarray arr, 
+		  NPY_TYPES expected_type);
 
   /** 
    *A free function that retrieves the number of dimensions of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the rank of an array.
    */
-  int rank(boost::python::numeric::array arr);
+  int rank(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual rank is not equal to the expected rank.
@@ -137,14 +138,14 @@ namespace num_util{
    *@param expected_rank an expected rank of the numeric array.
    *@return -----
    */
-  void check_rank(boost::python::numeric::array arr, int expected_rank);
+  void check_rank(boost::python::numpy::ndarray arr, int expected_rank);
   
   /** 
    *A free function that returns the total size of the array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the total size of the array.
    */
-  npy_intp size(boost::python::numeric::array arr);
+  npy_intp size(boost::python::numpy::ndarray arr);
   
   /** 
    *Throw an exception if the actual total size of the array is not equal to 
@@ -153,14 +154,14 @@ namespace num_util{
    *@param expected_size the expected size of an array.
    *@return -----
    */
-  void check_size(boost::python::numeric::array arr, npy_intp expected_size);
+  void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size);
 
   /** 
    *Returns the dimensions in a vector.
    *@param arr a Boost/Python numeric array.
    *@return a vector with integer values that indicates the shape of the array.
   */
-  std::vector<npy_intp> shape(boost::python::numeric::array arr);
+  std::vector<npy_intp> shape(boost::python::numpy::ndarray arr);
 
   /**
    *Returns the size of a specific dimension.
@@ -168,7 +169,7 @@ namespace num_util{
    *@param dimnum an integer that identifies the dimension to retrieve.
    *@return the size of the requested dimension.
    */
-  npy_intp get_dim(boost::python::numeric::array arr, int dimnum);
+  npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum);
 
   /** 
    *Throws an exception if the actual dimensions of the array are not equal to
@@ -177,8 +178,8 @@ namespace num_util{
    *@param expected_dims an integer vector of expected dimension.
    *@return -----
    */
-  void check_shape(boost::python::numeric::array arr, 
-       std::vector<npy_intp> expected_dims);
+  void check_shape(boost::python::numpy::ndarray arr, 
+		   std::vector<npy_intp> expected_dims);
 
   /**
    *Throws an exception if a specific dimension from a numpy array does not
@@ -188,28 +189,28 @@ namespace num_util{
    *@param dimsize an expected size of the specified dimension.
    *@return -----
   */
-  void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize);
+  void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize);
 
   /** 
    *Returns true if the array is contiguous.
    *@param arr a Boost/Python numeric array.
    *@return true if the array is contiguous, false otherwise.
   */
-  bool iscontiguous(boost::python::numeric::array arr);
+  bool iscontiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the array is not contiguous.
    *@param arr a Boost/Python numeric array.
    *@return -----
   */
-  void check_contiguous(boost::python::numeric::array arr);
+  void check_contiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns a pointer to the data in the array.
    *@param arr a Boost/Python numeric array.
    *@return a char pointer pointing at the first element of the array.
    */
-  void* data(boost::python::numeric::array arr);
+  void* data(boost::python::numpy::ndarray arr);
 
   /** 
    *Copies data into the array.
@@ -217,14 +218,14 @@ namespace num_util{
    *@param new_data a char pointer referencing the new data.
    *@return -----
    */
-  void copy_data(boost::python::numeric::array arr, char* new_data);
+  void copy_data(boost::python::numpy::ndarray arr, char* new_data);
   
   /** 
    *Returns a clone of this array.
    *@param arr a Boost/Python numeric array.
    *@return a replicate of the Boost/Python numeric array.
    */
-  boost::python::numeric::array clone(boost::python::numeric::array arr);
+  boost::python::numpy::ndarray clone(boost::python::numpy::ndarray arr);
   
   /** 
    *Returns a clone of this array with a new type.
@@ -232,22 +233,22 @@ namespace num_util{
    *@param t NPY_TYPES of the output array.
    *@return a replicate of 'arr' with type set to 't'.
    */
-  boost::python::numeric::array astype(boost::python::numeric::array arr, 
-               NPY_TYPES t);
+  boost::python::numpy::ndarray astype(boost::python::numpy::ndarray arr, 
+				       NPY_TYPES t);
 
 
 /*    *Returns the reference count of the array. */
 /*    *@param arr a Boost/Python numeric array. */
 /*    *@return the reference count of the array. */
 
-  int refcount(boost::python::numeric::array arr);
+  int refcount(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns the strides array in a vector of integer.
    *@param arr a Boost/Python numeric array.
    *@return the strides of an array.
    */
-  std::vector<npy_intp> strides(boost::python::numeric::array arr);
+  std::vector<npy_intp> strides(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the element of a numpy array is type cast to

--- a/adolc/sparse/src/py_sparse_adolc.cpp
+++ b/adolc/sparse/src/py_sparse_adolc.cpp
@@ -1,6 +1,6 @@
 #include "py_sparse_adolc.hpp"
 
-bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_options){
+bp::list	wrapped_jac_pat(short tape_tag, bpn::ndarray &bpn_x,bpn::ndarray &bpn_options){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	npy_intp N = tape_stats[NUM_INDEPENDENTS];
@@ -27,7 +27,7 @@ bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_optio
 }
 
 
-// bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options){
+// bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options){
 // 	size_t tape_stats[STAT_SIZE];
 // 	tapestats(tape_tag, tape_stats);
 // 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -49,9 +49,9 @@ bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_optio
 // 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_INT, (char*) cind )));
 // 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_DOUBLE, (char*) values )));
 
-// 	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-// 	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-// 	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+// 	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+// 	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+// 	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 // 	bp::list retvals;
 // 	retvals.append(ret_nnz);
@@ -63,7 +63,7 @@ bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_optio
 
 // }
 
-// bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values){
+// bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values){
 // 	size_t tape_stats[STAT_SIZE];
 // 	tapestats(tape_tag, tape_stats);
 // 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -82,9 +82,9 @@ bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_optio
 // 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &nnz, NPY_INT, (char*) cind )));
 // 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &nnz, NPY_DOUBLE, (char*) values )));
 
-// 	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-// 	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-// 	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+// 	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+// 	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+// 	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 // 	bp::list retvals;
 // 	retvals.append(nnz);
@@ -97,7 +97,7 @@ bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x,bpn::array &bpn_optio
 // }
 
 
-bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x,npy_intp option){
+bp::list	wrapped_hess_pat(short tape_tag, bpn::ndarray &bpn_x,npy_intp option){
 	size_t tape_stats[STAT_SIZE];
 	tapestats(tape_tag, tape_stats);
 	npy_intp N = tape_stats[NUM_INDEPENDENTS];
@@ -123,7 +123,7 @@ bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x,npy_intp option){
 	return ret_HP;
 }
 
-// bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options){
+// bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options){
 // 	size_t tape_stats[STAT_SIZE];
 // 	tapestats(tape_tag, tape_stats);
 // 	int N = tape_stats[NUM_INDEPENDENTS];
@@ -143,9 +143,9 @@ bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x,npy_intp option){
 // 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_INT, (char*) cind )));
 // 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &ret_nnz, NPY_DOUBLE, (char*) values )));
 
-// 	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-// 	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-// 	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+// 	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+// 	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+// 	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 // 	bp::list retvals;
 // 	retvals.append(ret_nnz);
@@ -157,7 +157,7 @@ bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x,npy_intp option){
 
 // }
 
-// bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values){
+// bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values){
 // 	size_t tape_stats[STAT_SIZE];
 // 	tapestats(tape_tag, tape_stats);
 // 	npy_intp N = tape_stats[NUM_INDEPENDENTS];
@@ -175,9 +175,9 @@ bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x,npy_intp option){
 // 	bp::object bp_cind   ( bp::handle<>(PyArray_SimpleNewFromData(1, &nnz, NPY_INT, (char*) cind )));
 // 	bp::object bp_values ( bp::handle<>(PyArray_SimpleNewFromData(1, &nnz, NPY_DOUBLE, (char*) values )));
 
-// 	bpn::array ret_rind   = boost::python::extract<boost::python::numeric::array>(bp_rind);
-// 	bpn::array ret_cind   = boost::python::extract<boost::python::numeric::array>(bp_cind);
-// 	bpn::array ret_values = boost::python::extract<boost::python::numeric::array>(bp_values);
+// 	bpn::ndarray ret_rind   = boost::python::extract<boost::python::numpy::ndarray>(bp_rind);
+// 	bpn::ndarray ret_cind   = boost::python::extract<boost::python::numpy::ndarray>(bp_cind);
+// 	bpn::ndarray ret_values = boost::python::extract<boost::python::numpy::ndarray>(bp_values);
 
 // 	bp::list retvals;
 // 	retvals.append(nnz);

--- a/adolc/sparse/src/py_sparse_adolc.hpp
+++ b/adolc/sparse/src/py_sparse_adolc.hpp
@@ -10,7 +10,7 @@
 using namespace std;
 namespace b = boost;
 namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
+namespace bpn = boost::python::numpy;
 namespace nu = num_util;
 
 // extern int jac_pat(short,int,int,double*,unsigned int**,int*);
@@ -21,24 +21,21 @@ namespace nu = num_util;
 // extern int sparse_hess(short, int , int, double*, int *, unsigned int **, unsigned int **, double **,int*);
 // extern int bit_vector_propagation(short, int, int, double*, unsigned int**, int*);
 
-bp::list	wrapped_jac_pat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options);
-// bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options);
-// bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values);
+bp::list	wrapped_jac_pat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options);
+// bp::list	wrapped_sparse_jac_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options);
+// bp::list	wrapped_sparse_jac_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values);
 
-bp::list	wrapped_hess_pat(short tape_tag, bpn::array &bpn_x, npy_intp option);
-// bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_options);
-// bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::array &bpn_x, npy_intp nnz, bpn::array &bpn_rind, bpn::array &bpn_cind, bpn::array &bpn_values);
+bp::list	wrapped_hess_pat(short tape_tag, bpn::ndarray &bpn_x, npy_intp option);
+// bp::list	wrapped_sparse_hess_no_repeat(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_options);
+// bp::list	wrapped_sparse_hess_repeat(short tape_tag, bpn::ndarray &bpn_x, npy_intp nnz, bpn::ndarray &bpn_rind, bpn::ndarray &bpn_cind, bpn::ndarray &bpn_values);
 
-
-
-
-
+#define NUMPY_IMPORT_ARRAY_RETVAL
 
 BOOST_PYTHON_MODULE(_sparse)
 {
 	using namespace boost::python;
-	import_array(); 										/* some kind of hack to get numpy working */
-	bpn::array::set_module_and_type("numpy", "ndarray");	/* some kind of hack to get numpy working */
+  bpn::initialize();
+  import_array();
 	def("jac_pat", 	             &wrapped_jac_pat);
 	// def("sparse_jac_no_repeat",  &wrapped_sparse_jac_no_repeat);
 	// def("sparse_jac_repeat",  &wrapped_sparse_jac_repeat);

--- a/adolc/sparse/tests/test_wrapped_functions.py
+++ b/adolc/sparse/tests/test_wrapped_functions.py
@@ -375,6 +375,6 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()
 

--- a/adolc/sparse/wrapped_functions.py
+++ b/adolc/sparse/wrapped_functions.py
@@ -1,5 +1,5 @@
-import _sparse
-from _sparse import *
+from . import _sparse
+from ._sparse import *
 
 import numpy
 

--- a/adolc/src/num_util.cpp
+++ b/adolc/src/num_util.cpp
@@ -182,7 +182,7 @@ static KindTypeMap kindtypes(kindTypeMapEntries,
                                    kindTypeMapEntries + numTypeEntries);
 
 //Create a numarray referencing Python sequence object
-numeric::array makeNum(object x){
+numpy::ndarray makeNum(object x){
   if (!PySequence_Check(x.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a sequence");
     throw_error_already_set();
@@ -190,33 +190,33 @@ numeric::array makeNum(object x){
   object obj(handle<>
 	     (PyArray_ContiguousFromObject(x.ptr(),NPY_NOTYPE,0,0)));
   check_PyArrayElementType(obj);
-  return extract<numeric::array>(obj); 
+  return extract<numpy::ndarray>(obj); 
 }
 
 //Create a one-dimensional Numeric array of length n and Numeric type t
-numeric::array makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
+numpy::ndarray makeNum(npy_intp n, NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(1, &n, t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
   
 //Create a Numeric array with dimensions dimens and Numeric type t
-numeric::array makeNum(std::vector<npy_intp> dimens, 
+numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
 		       NPY_TYPES t=NPY_DOUBLE){
   object obj(handle<>(PyArray_SimpleNew(dimens.size(), &dimens[0], t)));
-  return extract<numeric::array>(obj);
+  return extract<numpy::ndarray>(obj);
 }
 
-numeric::array makeNum(const numeric::array& arr){
-  //Returns a reference of arr by calling numeric::array copy constructor.
+numpy::ndarray makeNum(const numpy::ndarray& arr){
+  //Returns a reference of arr by calling numpy::ndarray copy constructor.
   //The copy constructor increases arr's reference count.
-  return numeric::array(arr);
+  return numpy::ndarray(arr);
 } 
 
-NPY_TYPES type(numeric::array arr){
+NPY_TYPES type(numpy::ndarray arr){
   return NPY_TYPES(PyArray_TYPE(reinterpret_cast<PyArrayObject*>(arr.ptr())));
 }
 
-void check_type(boost::python::numeric::array arr, 
+void check_type(boost::python::numpy::ndarray arr, 
 		NPY_TYPES expected_type){
   NPY_TYPES actual_type = type(arr);
   if (actual_type != expected_type) {
@@ -230,7 +230,7 @@ void check_type(boost::python::numeric::array arr,
 }
 
 //Return the number of dimensions
-int rank(numeric::array arr){
+int rank(numpy::ndarray arr){
   //std::cout << "inside rank" << std::endl;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -239,7 +239,7 @@ int rank(numeric::array arr){
   return PyArray_NDIM(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_rank(boost::python::numeric::array arr, int expected_rank){
+void check_rank(boost::python::numpy::ndarray arr, int expected_rank){
   int actual_rank = rank(arr);
   if (actual_rank != expected_rank) {
     std::ostringstream stream;
@@ -251,7 +251,7 @@ void check_rank(boost::python::numeric::array arr, int expected_rank){
   return;
 }
 
-npy_intp size(numeric::array arr)
+npy_intp size(numpy::ndarray arr)
 {
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -260,7 +260,7 @@ npy_intp size(numeric::array arr)
   return PyArray_Size(arr.ptr());
 }
 
-void check_size(boost::python::numeric::array arr, npy_intp expected_size){
+void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size){
   npy_intp actual_size = size(arr);
   if (actual_size != expected_size) {
     std::ostringstream stream;
@@ -272,7 +272,7 @@ void check_size(boost::python::numeric::array arr, npy_intp expected_size){
   return;
 }
 
-std::vector<npy_intp> shape(numeric::array arr){
+std::vector<npy_intp> shape(numpy::ndarray arr){
   std::vector<npy_intp> out_dims;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -286,7 +286,7 @@ std::vector<npy_intp> shape(numeric::array arr){
   return out_dims;
 }
 
-npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
+npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum){
   assert(dimnum >= 0);
   int the_rank=rank(arr);
   if(the_rank < dimnum){
@@ -300,7 +300,7 @@ npy_intp get_dim(boost::python::numeric::array arr, int dimnum){
   return actual_dims[dimnum];
 }
 
-void check_shape(boost::python::numeric::array arr, std::vector<npy_intp> expected_dims){
+void check_shape(boost::python::numpy::ndarray arr, std::vector<npy_intp> expected_dims){
   std::vector<npy_intp> actual_dims = shape(arr);
   if (actual_dims != expected_dims) {
     std::ostringstream stream;
@@ -312,7 +312,7 @@ void check_shape(boost::python::numeric::array arr, std::vector<npy_intp> expect
   return;
 }
 
-void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
+void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize){
   std::vector<npy_intp> actual_dims = shape(arr);
   if(actual_dims[dimnum] != dimsize){
     std::ostringstream stream;
@@ -325,13 +325,13 @@ void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize){
   return;
 }
 
-bool iscontiguous(numeric::array arr)
+bool iscontiguous(numpy::ndarray arr)
 {
   //  return arr.iscontiguous();
   return PyArray_ISCONTIGUOUS(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 
-void check_contiguous(numeric::array arr)
+void check_contiguous(numpy::ndarray arr)
 {
   if (!iscontiguous(arr)) {
     PyErr_SetString(PyExc_RuntimeError, "expected a contiguous array");
@@ -340,7 +340,7 @@ void check_contiguous(numeric::array arr)
   return;
 }
 
-void* data(numeric::array arr){
+void* data(numpy::ndarray arr){
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
     throw_error_already_set();
@@ -349,7 +349,7 @@ void* data(numeric::array arr){
 }
 
 //Copy data into the array
-void copy_data(boost::python::numeric::array arr, char* new_data){
+void copy_data(boost::python::numpy::ndarray arr, char* new_data){
   char* arr_data = (char*) data(arr);
   npy_intp nbytes = PyArray_NBYTES(reinterpret_cast<PyArrayObject*>(arr.ptr()));
   for (npy_intp i = 0; i < nbytes; i++) {
@@ -359,18 +359,18 @@ void copy_data(boost::python::numeric::array arr, char* new_data){
 } 
 
 //Return a clone of this array
-numeric::array clone(numeric::array arr){
+numpy::ndarray clone(numpy::ndarray arr){
   object obj(handle<>(PyArray_NewCopy(reinterpret_cast<PyArrayObject*>(arr.ptr()),NPY_CORDER)));
   return makeNum(obj);
 }
 
   
 //Return a clone of this array with a new type
-numeric::array astype(boost::python::numeric::array arr, NPY_TYPES t){
-  return (numeric::array) arr.astype(type2char(t));
+numpy::ndarray astype(boost::python::numpy::ndarray arr, NPY_TYPES t){
+  return (numpy::ndarray) arr.astype(boost::python::numpy::dtype(boost::python::str(type2char(t))));
 }
 
-std::vector<npy_intp> strides(numeric::array arr){
+std::vector<npy_intp> strides(numpy::ndarray arr){
   std::vector<npy_intp> out_strides;
   if(!PyArray_Check(reinterpret_cast<PyArrayObject*>(arr.ptr()))){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -384,7 +384,7 @@ std::vector<npy_intp> strides(numeric::array arr){
   return out_strides;
 }
 
-int refcount(numeric::array arr){
+int refcount(numpy::ndarray arr){
   return REFCOUNT(reinterpret_cast<PyArrayObject*>(arr.ptr()));
 }
 

--- a/adolc/src/num_util.h
+++ b/adolc/src/num_util.h
@@ -12,6 +12,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
 #include <numpy/noprefix.h>
 #include <iostream>
 #include <sstream>
@@ -29,7 +30,7 @@ namespace num_util{
    *@param x a sequential PyObject wrapped in a Boost/Python 'object'.
    *@return a PyArrayObject wrapped in Boost/Python numeric array.
    */
-  boost::python::numeric::array makeNum(boost::python::object x);
+  boost::python::numpy::ndarray makeNum(boost::python::object x);
 
   /** 
    *Creates an one-dimensional numpy array of length n and numpy type t. 
@@ -38,7 +39,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of size n with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(npy_intp n, NPY_TYPES t);
+  boost::python::numpy::ndarray makeNum(npy_intp n, NPY_TYPES t);
 
   /** 
    *Creates a n-dimensional numpy array with dimensions dimens and numpy 
@@ -47,7 +48,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of shape dimens with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(std::vector<npy_intp> dimens, 
+  boost::python::numpy::ndarray makeNum(std::vector<npy_intp> dimens, 
 					NPY_TYPES t);
 				      
   /** 
@@ -73,11 +74,11 @@ namespace num_util{
    *@return a numpy array of size n with elements initialized to data.
    */
 
-  template <typename T> boost::python::numeric::array makeNum(T* data, npy_intp n = 0){
+  template <typename T> boost::python::numpy::ndarray makeNum(T* data, npy_intp n = 0){
     boost::python::object obj(boost::python::handle<>((PyArray_SimpleNew(1, &n, getEnum<T>()))));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * n); // copies the input data to 
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
 
   /** 
@@ -90,12 +91,12 @@ namespace num_util{
    */
 
 
-  template <typename T> boost::python::numeric::array makeNum(T * data, std::vector<npy_intp> dims){
+  template <typename T> boost::python::numpy::ndarray makeNum(T * data, std::vector<npy_intp> dims){
     npy_intp total = std::accumulate(dims.begin(),dims.end(),1,std::multiplies<npy_intp>());
     boost::python::object obj(boost::python::handle<>(PyArray_SimpleNew(dims.size(),&dims[0], getEnum<T>())));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * total);
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<boost::python::numpy::ndarray>(obj);
   }
     
 
@@ -104,15 +105,15 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return a numeric array referencing the input array.
    */
-  boost::python::numeric::array makeNum(const 
-					boost::python::numeric::array& arr);
+  boost::python::numpy::ndarray makeNum(const 
+					boost::python::numpy::ndarray& arr);
 
   /** 
    *A free function that retrieves the numpy type of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return the numpy type of the array's elements 
    */
-  NPY_TYPES type(boost::python::numeric::array arr);
+  NPY_TYPES type(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual array type is not equal to the expected 
@@ -121,7 +122,7 @@ namespace num_util{
    *@param expected_type an expected numpy type.
    *@return -----
    */
-  void check_type(boost::python::numeric::array arr, 
+  void check_type(boost::python::numpy::ndarray arr, 
 		  NPY_TYPES expected_type);
 
   /** 
@@ -129,7 +130,7 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the rank of an array.
    */
-  int rank(boost::python::numeric::array arr);
+  int rank(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the actual rank is not equal to the expected rank.
@@ -137,14 +138,14 @@ namespace num_util{
    *@param expected_rank an expected rank of the numeric array.
    *@return -----
    */
-  void check_rank(boost::python::numeric::array arr, int expected_rank);
+  void check_rank(boost::python::numpy::ndarray arr, int expected_rank);
   
   /** 
    *A free function that returns the total size of the array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the total size of the array.
    */
-  npy_intp size(boost::python::numeric::array arr);
+  npy_intp size(boost::python::numpy::ndarray arr);
   
   /** 
    *Throw an exception if the actual total size of the array is not equal to 
@@ -153,14 +154,14 @@ namespace num_util{
    *@param expected_size the expected size of an array.
    *@return -----
    */
-  void check_size(boost::python::numeric::array arr, npy_intp expected_size);
+  void check_size(boost::python::numpy::ndarray arr, npy_intp expected_size);
 
   /** 
    *Returns the dimensions in a vector.
    *@param arr a Boost/Python numeric array.
    *@return a vector with integer values that indicates the shape of the array.
   */
-  std::vector<npy_intp> shape(boost::python::numeric::array arr);
+  std::vector<npy_intp> shape(boost::python::numpy::ndarray arr);
 
   /**
    *Returns the size of a specific dimension.
@@ -168,7 +169,7 @@ namespace num_util{
    *@param dimnum an integer that identifies the dimension to retrieve.
    *@return the size of the requested dimension.
    */
-  npy_intp get_dim(boost::python::numeric::array arr, int dimnum);
+  npy_intp get_dim(boost::python::numpy::ndarray arr, int dimnum);
 
   /** 
    *Throws an exception if the actual dimensions of the array are not equal to
@@ -177,7 +178,7 @@ namespace num_util{
    *@param expected_dims an integer vector of expected dimension.
    *@return -----
    */
-  void check_shape(boost::python::numeric::array arr, 
+  void check_shape(boost::python::numpy::ndarray arr, 
 		   std::vector<npy_intp> expected_dims);
 
   /**
@@ -188,28 +189,28 @@ namespace num_util{
    *@param dimsize an expected size of the specified dimension.
    *@return -----
   */
-  void check_dim(boost::python::numeric::array arr, int dimnum, npy_intp dimsize);
+  void check_dim(boost::python::numpy::ndarray arr, int dimnum, npy_intp dimsize);
 
   /** 
    *Returns true if the array is contiguous.
    *@param arr a Boost/Python numeric array.
    *@return true if the array is contiguous, false otherwise.
   */
-  bool iscontiguous(boost::python::numeric::array arr);
+  bool iscontiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the array is not contiguous.
    *@param arr a Boost/Python numeric array.
    *@return -----
   */
-  void check_contiguous(boost::python::numeric::array arr);
+  void check_contiguous(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns a pointer to the data in the array.
    *@param arr a Boost/Python numeric array.
    *@return a char pointer pointing at the first element of the array.
    */
-  void* data(boost::python::numeric::array arr);
+  void* data(boost::python::numpy::ndarray arr);
 
   /** 
    *Copies data into the array.
@@ -217,14 +218,14 @@ namespace num_util{
    *@param new_data a char pointer referencing the new data.
    *@return -----
    */
-  void copy_data(boost::python::numeric::array arr, char* new_data);
+  void copy_data(boost::python::numpy::ndarray arr, char* new_data);
   
   /** 
    *Returns a clone of this array.
    *@param arr a Boost/Python numeric array.
    *@return a replicate of the Boost/Python numeric array.
    */
-  boost::python::numeric::array clone(boost::python::numeric::array arr);
+  boost::python::numpy::ndarray clone(boost::python::numpy::ndarray arr);
   
   /** 
    *Returns a clone of this array with a new type.
@@ -232,7 +233,7 @@ namespace num_util{
    *@param t NPY_TYPES of the output array.
    *@return a replicate of 'arr' with type set to 't'.
    */
-  boost::python::numeric::array astype(boost::python::numeric::array arr, 
+  boost::python::numpy::ndarray astype(boost::python::numpy::ndarray arr, 
 				       NPY_TYPES t);
 
 
@@ -240,14 +241,14 @@ namespace num_util{
 /*    *@param arr a Boost/Python numeric array. */
 /*    *@return the reference count of the array. */
 
-  int refcount(boost::python::numeric::array arr);
+  int refcount(boost::python::numpy::ndarray arr);
 
   /** 
    *Returns the strides array in a vector of integer.
    *@param arr a Boost/Python numeric array.
    *@return the strides of an array.
    */
-  std::vector<npy_intp> strides(boost::python::numeric::array arr);
+  std::vector<npy_intp> strides(boost::python::numpy::ndarray arr);
 
   /** 
    *Throws an exception if the element of a numpy array is type cast to

--- a/adolc/src/py_adolc.cpp
+++ b/adolc/src/py_adolc.cpp
@@ -73,17 +73,17 @@ adouble wrapped_condassign_adouble_if_else(adouble &res, const adouble &cond, co
 
 /* C STYLE CALLS OF FUNCTIONS */
 /* easy to use drivers */
-int c_wrapped_function			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_y ){
+int c_wrapped_function			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_y ){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	return ::function(tape_tag, M, N, x, y);
 }
-int c_wrapped_gradient			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_g){
+int c_wrapped_gradient			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_g){
 	double* x = (double*) nu::data(bpn_x);
 	double* g = (double*) nu::data(bpn_g);
 	return gradient(tape_tag, N, x, g);
 }
-int c_wrapped_hessian			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_H){
+int c_wrapped_hessian			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_H){
 	double* x = (double*) nu::data(bpn_x);
 	double* H_data = (double*) nu::data(bpn_H);
 	double* H[N];
@@ -92,7 +92,7 @@ int c_wrapped_hessian			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &b
 	}
 	return hessian(tape_tag, N, x, H);
 }
-int c_wrapped_jacobian			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_J){
+int c_wrapped_jacobian			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_J){
 	double* x = (double*) nu::data(bpn_x);
 	double* J[M];
 	double* J_data = (double*) nu::data(bpn_J);
@@ -101,25 +101,25 @@ int c_wrapped_jacobian			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::
 	}
 	return jacobian(tape_tag, M, N, x, J);
 }
-int c_wrapped_vec_jac			(short tape_tag, int M, int N, bool repeat, bpn::array &bpn_x, bpn::array &bpn_u, bpn::array &bpn_z){
+int c_wrapped_vec_jac			(short tape_tag, int M, int N, bool repeat, bpn::ndarray &bpn_x, bpn::ndarray &bpn_u, bpn::ndarray &bpn_z){
 	double* x = (double*) nu::data(bpn_x);
 	double* u = (double*) nu::data(bpn_u);
 	double* z = (double*) nu::data(bpn_z);
 	return vec_jac(tape_tag, M, N, repeat, x, u, z);
 }
-int c_wrapped_jac_vec			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_z){
+int c_wrapped_jac_vec			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_z){
 	double* x = (double*) nu::data(bpn_x);
 	double* v = (double*) nu::data(bpn_v);
 	double* z = (double*) nu::data(bpn_z);
 	return jac_vec(tape_tag, M, N, x, v, z);
 }
-int c_wrapped_hess_vec			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_z){
+int c_wrapped_hess_vec			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_z){
 	double* x = (double*) nu::data(bpn_x);
 	double* v = (double*) nu::data(bpn_v);
 	double* z = (double*) nu::data(bpn_z);
 	return hess_vec(tape_tag, N, x, v, z);
 }
-int c_wrapped_lagra_hess_vec	(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_u,bpn::array &bpn_h){
+int c_wrapped_lagra_hess_vec	(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_u,bpn::ndarray &bpn_h){
 
 	double* x = (double*) nu::data(bpn_x);
 	double* v = (double*) nu::data(bpn_v);
@@ -127,19 +127,19 @@ int c_wrapped_lagra_hess_vec	(short tape_tag, int M, int N, bpn::array &bpn_x, b
 	double* h = (double*) nu::data(bpn_h);
 	return lagra_hess_vec(tape_tag, M, N, x, v, u, h);
 }
-// int c_wrapped_jac_solv			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_b, int sparse, int mode){
+// int c_wrapped_jac_solv			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_b, int sparse, int mode){
 // 	double* x = (double*) nu::data(bpn_x);
 // 	double* b = (double*) nu::data(bpn_b);
 // 	jac_solv(tape_tag, N, x, b, sparse, mode);
 // }
 
 /* low level functions */
-int c_wrapped_zos_forward		(short tape_tag, int M, int N, int keep, bpn::array &bpn_x, bpn::array &bpn_y){
+int c_wrapped_zos_forward		(short tape_tag, int M, int N, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_y){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	return zos_forward(tape_tag, M, N, keep, x, y);
 }
-int c_wrapped_fos_forward		(short tape_tag, int M, int N, int keep, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_y, bpn::array &bpn_w){
+int c_wrapped_fos_forward		(short tape_tag, int M, int N, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_y, bpn::ndarray &bpn_w){
 
 	double* x = (double*) nu::data(bpn_x);
 	double* v = (double*) nu::data(bpn_v);
@@ -149,7 +149,7 @@ int c_wrapped_fos_forward		(short tape_tag, int M, int N, int keep, bpn::array &
 	return fos_forward(tape_tag, M, N, keep, x, v, y, w);
 }
 
-int c_wrapped_fov_forward		(short tape_tag, int M, int N, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W){
+int c_wrapped_fov_forward		(short tape_tag, int M, int N, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	double* V_data = (double*) nu::data(bpn_V);
@@ -166,7 +166,7 @@ int c_wrapped_fov_forward		(short tape_tag, int M, int N, int P, bpn::array &bpn
 	return fov_forward(tape_tag, M, N, P, x, V, y, W);
 }
 
-int c_wrapped_hos_forward		(short tape_tag, int M, int N, int D, int keep, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W){
+int c_wrapped_hos_forward		(short tape_tag, int M, int N, int D, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	double* V_data = (double*) nu::data(bpn_V);
@@ -182,7 +182,7 @@ int c_wrapped_hos_forward		(short tape_tag, int M, int N, int D, int keep, bpn::
 	return hos_forward(tape_tag, M, N, D, keep, x, V, y, W);
 }
 
-int c_wrapped_hov_forward		(short tape_tag, int M, int N, int D, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W){
+int c_wrapped_hov_forward		(short tape_tag, int M, int N, int D, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	double* V_data = (double*) nu::data(bpn_V);
@@ -209,7 +209,7 @@ int c_wrapped_hov_forward		(short tape_tag, int M, int N, int D, int P, bpn::arr
 	return hov_forward(tape_tag, M, N, D, P, x, V, y, W);
 }
 
-int c_wrapped_hov_wk_forward	(short tape_tag, int M, int N, int D, int keep, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W){
+int c_wrapped_hov_wk_forward	(short tape_tag, int M, int N, int D, int keep, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W){
 	double* x = (double*) nu::data(bpn_x);
 	double* y = (double*) nu::data(bpn_y);
 	double* V_data = (double*) nu::data(bpn_V);
@@ -237,13 +237,13 @@ int c_wrapped_hov_wk_forward	(short tape_tag, int M, int N, int D, int keep, int
 }
 
 
-int c_wrapped_fos_reverse		(short tape_tag, int M, int N, bpn::array &bpn_u, bpn::array &bpn_z){
+int c_wrapped_fos_reverse		(short tape_tag, int M, int N, bpn::ndarray &bpn_u, bpn::ndarray &bpn_z){
 	double* u = (double*) nu::data(bpn_u);
 	double* z = (double*) nu::data(bpn_z);
 	return fos_reverse(tape_tag, M, N, u, z);
 }
 
-int c_wrapped_fov_reverse		(short tape_tag, int M, int N, int Q, bpn::array &bpn_U, bpn::array &bpn_Z){
+int c_wrapped_fov_reverse		(short tape_tag, int M, int N, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z){
 	double* U_data = (double*) nu::data(bpn_U);
 	double* U[Q];
 	for(int q = 0; q != Q; ++q){
@@ -257,7 +257,7 @@ int c_wrapped_fov_reverse		(short tape_tag, int M, int N, int Q, bpn::array &bpn
 	}
 	return fov_reverse(tape_tag, M, N, Q, U, Z);
 }
-int c_wrapped_hos_reverse		(short tape_tag, int M, int N, int D, bpn::array &bpn_u, bpn::array &bpn_Z){
+int c_wrapped_hos_reverse		(short tape_tag, int M, int N, int D, bpn::ndarray &bpn_u, bpn::ndarray &bpn_Z){
 	double* u = (double*) nu::data(bpn_u);
 	double* Z_data = (double*) nu::data(bpn_Z);
 	double* Z[N];
@@ -267,7 +267,7 @@ int c_wrapped_hos_reverse		(short tape_tag, int M, int N, int D, bpn::array &bpn
 	return hos_reverse(tape_tag, M, N, D, u, Z);
 }
 
-int c_wrapped_hos_ti_reverse   (short tape_tag, int M, int N, int D, bpn::array &bpn_U, bpn::array &bpn_Z){
+int c_wrapped_hos_ti_reverse   (short tape_tag, int M, int N, int D, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z){
 	double* U_data = (double*) nu::data(bpn_U);
 	double* U[M];
 	for(int m = 0; m != M; ++m){
@@ -282,7 +282,7 @@ int c_wrapped_hos_ti_reverse   (short tape_tag, int M, int N, int D, bpn::array 
 }
 
 
-int c_wrapped_hov_reverse		(short tape_tag, int M, int N, int D, int Q, bpn::array &bpn_U, bpn::array &bpn_Z, bpn::array &bpn_nz){
+int c_wrapped_hov_reverse		(short tape_tag, int M, int N, int D, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z, bpn::ndarray &bpn_nz){
 	double* U_data = (double*) nu::data(bpn_U);
 	double* U[Q];
 	for(int q = 0; q != Q; ++q){
@@ -308,7 +308,7 @@ int c_wrapped_hov_reverse		(short tape_tag, int M, int N, int D, int Q, bpn::arr
 }
 
 
-int c_wrapped_hov_ti_reverse	(short tape_tag, int M, int N, int D, int Q, bpn::array &bpn_U, bpn::array &bpn_Z, bpn::array &bpn_nz){
+int c_wrapped_hov_ti_reverse	(short tape_tag, int M, int N, int D, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z, bpn::ndarray &bpn_nz){
 
 	/* U is (Q, M, D+1) matrix */
 	double* U_data = (double*) nu::data(bpn_U);
@@ -348,7 +348,7 @@ int c_wrapped_hov_ti_reverse	(short tape_tag, int M, int N, int D, int Q, bpn::a
 }
 
 
-int c_wrapped_hos_ov_reverse	(short tape_tag, int M, int N, int D, int P, bpn::array &bpn_U, bpn::array &bpn_Z){
+int c_wrapped_hos_ov_reverse	(short tape_tag, int M, int N, int D, int P, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z){
 	/* this function is experimental and likely not to work ... */
 
 	/* U is (M,D+1) array */
@@ -378,7 +378,7 @@ int c_wrapped_hos_ov_reverse	(short tape_tag, int M, int N, int D, int P, bpn::a
 
 
 
-void py_tape_doc(short tape_tag, bpn::array &x, bpn::array &y ){
+void py_tape_doc(short tape_tag, bpn::ndarray &x, bpn::ndarray &y ){
 	nu::check_rank(x,1);
 	nu::check_rank(y,1);
 
@@ -391,7 +391,7 @@ void py_tape_doc(short tape_tag, bpn::array &x, bpn::array &y ){
 }
 
 // /* from taping.h and taping.c */
-// bpn::array wrapped_tapestats(short tape_tag) {
+// bpn::ndarray wrapped_tapestats(short tape_tag) {
 // 	int tape_stats[STAT_SIZE];
 // 	tapestats(tape_tag, tape_stats);
 // 	return nu::makeNum( tape_stats, STAT_SIZE);

--- a/adolc/src/py_adolc.hpp
+++ b/adolc/src/py_adolc.hpp
@@ -10,7 +10,7 @@
 using namespace std;
 namespace b = boost;
 namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
+namespace bpn = boost::python::numpy;
 namespace nu = num_util;
 
 
@@ -74,35 +74,35 @@ int trace_on_default_argument(short tape_tag){ return trace_on(tape_tag,0);}
 void trace_off_default_argument(){ trace_off(0);}
 
 /* C STYLE CALLS OF FUNCTIONS */
-int c_wrapped_function			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_y );
-int c_wrapped_gradient			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_g);
-int c_wrapped_hessian			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_H);
-int c_wrapped_jacobian			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_J);
-int c_wrapped_vec_jac			(short tape_tag, int M, int N, bool repeat, bpn::array &bpn_x, bpn::array &bpn_u, bpn::array &bpn_z);
-int c_wrapped_jac_vec			(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_z);
-int c_wrapped_hess_vec			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_z);
-int c_wrapped_lagra_hess_vec	(short tape_tag, int M, int N, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_u,bpn::array &bpn_h);
-// int c_wrapped_jac_solv			(short tape_tag, int N, bpn::array &bpn_x, bpn::array &bpn_b, int sparse, int mode);
-int c_wrapped_zos_forward		(short tape_tag, int M, int N, int keep, bpn::array &bpn_x, bpn::array &bpn_y);
-int c_wrapped_fos_forward		(short tape_tag, int M, int N, int keep, bpn::array &bpn_x, bpn::array &bpn_v, bpn::array &bpn_y, bpn::array &bpn_w);
-int c_wrapped_fov_forward		(short tape_tag, int M, int N, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W);
-int c_wrapped_hos_forward		(short tape_tag, int M, int N, int D, int keep, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W);
-int c_wrapped_hov_forward		(short tape_tag, int M, int N, int D, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W);
-int c_wrapped_hov_wk_forward	(short tape_tag, int M, int N, int D, int keep, int P, bpn::array &bpn_x, bpn::array &bpn_V, bpn::array &bpn_y, bpn::array &bpn_W);
+int c_wrapped_function			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_y );
+int c_wrapped_gradient			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_g);
+int c_wrapped_hessian			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_H);
+int c_wrapped_jacobian			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_J);
+int c_wrapped_vec_jac			(short tape_tag, int M, int N, bool repeat, bpn::ndarray &bpn_x, bpn::ndarray &bpn_u, bpn::ndarray &bpn_z);
+int c_wrapped_jac_vec			(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_z);
+int c_wrapped_hess_vec			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_z);
+int c_wrapped_lagra_hess_vec	(short tape_tag, int M, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_u,bpn::ndarray &bpn_h);
+// int c_wrapped_jac_solv			(short tape_tag, int N, bpn::ndarray &bpn_x, bpn::ndarray &bpn_b, int sparse, int mode);
+int c_wrapped_zos_forward		(short tape_tag, int M, int N, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_y);
+int c_wrapped_fos_forward		(short tape_tag, int M, int N, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_v, bpn::ndarray &bpn_y, bpn::ndarray &bpn_w);
+int c_wrapped_fov_forward		(short tape_tag, int M, int N, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W);
+int c_wrapped_hos_forward		(short tape_tag, int M, int N, int D, int keep, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W);
+int c_wrapped_hov_forward		(short tape_tag, int M, int N, int D, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W);
+int c_wrapped_hov_wk_forward	(short tape_tag, int M, int N, int D, int keep, int P, bpn::ndarray &bpn_x, bpn::ndarray &bpn_V, bpn::ndarray &bpn_y, bpn::ndarray &bpn_W);
 
 
-int c_wrapped_fos_reverse		(short tape_tag, int M, int N, bpn::array &bpn_u, bpn::array &bpn_z);
-int c_wrapped_fov_reverse		(short tape_tag, int M, int N, int Q, bpn::array &bpn_U, bpn::array &bpn_Z);
-int c_wrapped_hos_reverse		(short tape_tag, int M, int N, int D, bpn::array &bpn_u, bpn::array &bpn_Z);
-int c_wrapped_hos_ti_reverse   (short tape_tag, int M, int N, int D, bpn::array &bpn_U, bpn::array &bpn_Z);
+int c_wrapped_fos_reverse		(short tape_tag, int M, int N, bpn::ndarray &bpn_u, bpn::ndarray &bpn_z);
+int c_wrapped_fov_reverse		(short tape_tag, int M, int N, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z);
+int c_wrapped_hos_reverse		(short tape_tag, int M, int N, int D, bpn::ndarray &bpn_u, bpn::ndarray &bpn_Z);
+int c_wrapped_hos_ti_reverse   (short tape_tag, int M, int N, int D, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z);
 
 
-int c_wrapped_hov_reverse		(short tape_tag, int M, int N, int D, int Q, bpn::array &bpn_U, bpn::array &bpn_Z, bpn::array &bpn_nz);
-int c_wrapped_hov_ti_reverse	(short tape_tag, int M, int N, int D, int Q, bpn::array &bpn_U, bpn::array &bpn_Z, bpn::array &bpn_nz);
-int c_wrapped_hos_ov_reverse	(short tape_tag, int M, int N, int D, int P, bpn::array &bpn_U, bpn::array &bpn_Z);
+int c_wrapped_hov_reverse		(short tape_tag, int M, int N, int D, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z, bpn::ndarray &bpn_nz);
+int c_wrapped_hov_ti_reverse	(short tape_tag, int M, int N, int D, int Q, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z, bpn::ndarray &bpn_nz);
+int c_wrapped_hos_ov_reverse	(short tape_tag, int M, int N, int D, int P, bpn::ndarray &bpn_U, bpn::ndarray &bpn_Z);
 
 
-void py_tape_doc(short tape_tag, bpn::array &bpn_x, bpn::array &bpn_y );
+void py_tape_doc(short tape_tag, bpn::ndarray &bpn_x, bpn::ndarray &bpn_y );
 bp::dict wrapped_tapestats(short tape_tag);
 
 /* of class badouble */
@@ -202,12 +202,14 @@ badouble& (badouble::*operator_eq_double) ( double ) = &badouble::operator=;
 badouble& (badouble::*operator_eq_badouble) ( const badouble& ) = &badouble::operator=;
 badouble& (badouble::*operator_eq_adub) ( const adub& ) = &badouble::operator=;
 
+#define NUMPY_IMPORT_ARRAY_RETVAL
 
 BOOST_PYTHON_MODULE(_adolc)
 {
 	using namespace boost::python;
+  boost::python::numpy::initialize();
 	import_array(); 										/* some kind of hack to get numpy working */
-	bpn::array::set_module_and_type("numpy", "ndarray");	/* some kind of hack to get numpy working */
+	//bpn::ndarray::set_module_and_type("numpy", "ndarray");	/* some kind of hack to get numpy working */
 
 	scope().attr("__doc__") ="unused: moved docstring to adolc.py";
 

--- a/adolc/src/py_interpolation.cpp
+++ b/adolc/src/py_interpolation.cpp
@@ -10,7 +10,7 @@ static inline int _(const int I, const int J, const int K,
     return J*K*i + K*j +k;
 }
 
-void entangle_cross(bpn::array &bpn_V, bpn::array &bpn_V1, bpn::array &bpn_V2, bpn::array &bpn_V12){
+void entangle_cross(bpn::ndarray &bpn_V, bpn::ndarray &bpn_V1, bpn::ndarray &bpn_V2, bpn::ndarray &bpn_V12){
 
     double* V   = (double*) nu::data(bpn_V);
     double* V1  = (double*) nu::data(bpn_V1);
@@ -73,7 +73,7 @@ void entangle_cross(bpn::array &bpn_V, bpn::array &bpn_V1, bpn::array &bpn_V2, b
 }
 
 
-void detangle_cross(bpn::array &bpn_V, bpn::array &bpn_V1, bpn::array &bpn_V2, bpn::array &bpn_V12){
+void detangle_cross(bpn::ndarray &bpn_V, bpn::ndarray &bpn_V1, bpn::ndarray &bpn_V2, bpn::ndarray &bpn_V12){
 
     double* V   = (double*) nu::data(bpn_V);
     double* V1  = (double*) nu::data(bpn_V1);

--- a/adolc/src/py_interpolation.h
+++ b/adolc/src/py_interpolation.h
@@ -6,7 +6,7 @@
 using namespace std;
 namespace b = boost;
 namespace bp = boost::python;
-namespace bpn = boost::python::numeric;
+namespace bpn = boost::python::numpy;
 namespace nu = num_util;
 
 /**
@@ -42,7 +42,7 @@ N = number of input arguments
 D = 2 = order of the Taylor polynomial
 P = M*L + M + L number of entangled directions
 */
-void entangle_cross(bpn::array &V, bpn::array &V1, bpn::array &V2, bpn::array &V12);
+void entangle_cross(bpn::ndarray &V, bpn::ndarray &V1, bpn::ndarray &V2, bpn::ndarray &V12);
 
 /**
 
@@ -69,7 +69,7 @@ V12     (OUTPUT) DArray
 
 
 */
-void detangle_cross(bpn::array &V, bpn::array &V1, bpn::array &V2, bpn::array &V12);
+void detangle_cross(bpn::ndarray &V, bpn::ndarray &V1, bpn::ndarray &V2, bpn::ndarray &V12);
 
 
 #endif

--- a/adolc/tests/test_cgraph.py
+++ b/adolc/tests/test_cgraph.py
@@ -129,5 +129,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/tests/test_finitedifferences.py
+++ b/adolc/tests/test_finitedifferences.py
@@ -28,5 +28,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/tests/test_interpolation.py
+++ b/adolc/tests/test_interpolation.py
@@ -46,5 +46,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/tests/test_linalg.py
+++ b/adolc/tests/test_linalg.py
@@ -52,5 +52,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/tests/test_tangent.py
+++ b/adolc/tests/test_tangent.py
@@ -63,7 +63,7 @@ class SemiImplicitOdeLhsTest(TestCase):
     
     def test_differentiation_of_gfcn(self):
         def gfcn(a):
-            print 'called gfcn'
+            print('called gfcn')
             ty = [Tangent(a.xd[0], a.xdd[0]),Tangent(a.xd[1], a.xdd[1]), Tangent(a.xd[2], a.xdd[2])]
             tlhs = [ty[0] * ty[2], ty[1] * ty[2], ty[2]]
             
@@ -127,5 +127,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/tests/test_wrapped_functions.py
+++ b/adolc/tests/test_wrapped_functions.py
@@ -23,8 +23,8 @@ class OperationsTests ( TestCase ):
         assert b.val == -1.
         assert a.val == 1.
 
-        print type(b)
-        print type(a)
+        print(type(b))
+        print(type(a))
 
     def test_conditional_operators(self):
         ax = adouble(2.)
@@ -193,14 +193,14 @@ class OperationsTests ( TestCase ):
         cond = 1.
 
         x = condassign(x,cond,y)
-        print x
+        print(x)
         assert_almost_equal(x,4.)
 
         x = 3.
         y = 4.
         cond = -1.
         x = condassign(x,cond,y)
-        print x
+        print(x)
         assert_almost_equal(x,3.)
 
     def test_double_condassign_if_else(self):
@@ -227,14 +227,14 @@ class OperationsTests ( TestCase ):
         cond = adouble(1.)
 
         x = condassign(x,cond,y)
-        print x
+        print(x)
         assert_almost_equal(x.val, 4.)
 
         x = adouble(3.)
         y = adouble(4.)
         cond = adouble(-3.)
         x = condassign(x,cond,y)
-        print x
+        print(x)
         assert_almost_equal(x.val, 3.)
 
 
@@ -276,7 +276,7 @@ class OperationsTests ( TestCase ):
         cond = adouble(1.)
 
         x = condassign(x,cond,y,z)
-        print x
+        print(x)
         assert_almost_equal(x.val, 4.)
 
         x = adouble(3.)
@@ -285,7 +285,7 @@ class OperationsTests ( TestCase ):
         cond = adouble(-3.)
 
         x = condassign(x,cond,y,z)
-        print x
+        print(x)
         assert_almost_equal(x.val, 5.)
 
 
@@ -312,8 +312,8 @@ class CorrectnessTests(TestCase):
 
         g = gradient(0,x)
 
-        print g
-        print eval_g(x)
+        print(g)
+        print(eval_g(x))
 
 
 class LowLevelFunctionsTests ( TestCase ):
@@ -411,7 +411,7 @@ class LowLevelFunctionsTests ( TestCase ):
         U[0,0,0] = 1.
 
         Z = hov_ti_reverse(0,U)[0]
-        print Z[0,:,0]
+        print(Z[0,:,0])
         assert numpy.prod( Z[0,:,0] == numpy.array([35., 21., 15.]))
         assert numpy.prod( Z[0,:,1] == numpy.array([0., 7., 5.]))
 
@@ -703,6 +703,6 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()
 

--- a/adolc/tests/test_wrapped_functions_complicated.py
+++ b/adolc/tests/test_wrapped_functions_complicated.py
@@ -350,8 +350,8 @@ class TestNonlinearRegression(TestCase):
                 n = self.n
                 y = [numpy.fabs(i) for i in x[:-2]]
                 y.insert(0, numpy.fabs(n - sum(y[:n-1])))
-                a = dict(zip(self.names, y[:n]))
-                b = dict(zip(self.names, y[n:]))
+                a = dict(list(zip(self.names, y[:n])))
+                b = dict(list(zip(self.names, y[n:])))
                 g = numpy.fabs(x[-2])
                 r = x[-1]
                 pseudo_loglikelihood = 0

--- a/adolc/tests/test_wrapped_functions_future.py
+++ b/adolc/tests/test_wrapped_functions_future.py
@@ -3,7 +3,7 @@ In this file, there should be tests that check  if future API changes of Python/
 will break pyadolc.
 """
 
-from __future__ import division
+
 from numpy.testing import *
 
 from adolc import *
@@ -29,5 +29,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/adolc/wrapped_functions.py
+++ b/adolc/wrapped_functions.py
@@ -1,6 +1,6 @@
 import numpy
-import _adolc
-from _adolc import *
+from . import _adolc
+from ._adolc import *
 
 class ErrorReturnCode(Exception):
     """
@@ -68,7 +68,7 @@ def independent(ax):
         axr = numpy.ravel(ax)
         N   = numpy.size(axr)
         xr = numpy.array([axr[n].val for n in range(N)])
-        map(_adolc.adouble.is_independent,axr,xr)
+        list(map(_adolc.adouble.is_independent,axr,xr))
         return ax
 
 

--- a/examples/comparison_with_sympy.py
+++ b/examples/comparison_with_sympy.py
@@ -114,23 +114,23 @@ adolc.trace_off()
 # point at which the derivatives should be evaluated
 x = random((N,D))
 
-print '\n\n'
-print 'Sympy function = function  check (should be almost zero)'
-print f(x) - sym_f(x)
+print('\n\n')
+print('Sympy function = function  check (should be almost zero)')
+print(f(x) - sym_f(x))
 
-print '\n\n'
-print 'Sympy vs Hand Derived Gradient check (should be almost zero)'
-print df(x) - sym_df(x)
+print('\n\n')
+print('Sympy vs Hand Derived Gradient check (should be almost zero)')
+print(df(x) - sym_df(x))
 
-print 'Sympy vs Ad Derived Gradient check (should be almost zero)'
-print adolc.gradient(0, numpy.ravel(x)).reshape(x.shape) - sym_df(x)
+print('Sympy vs Ad Derived Gradient check (should be almost zero)')
+print(adolc.gradient(0, numpy.ravel(x)).reshape(x.shape) - sym_df(x))
 
-print '\n\n'
-print 'Sympy vs Hand Derived Hessian check (should be almost zero)'
-print ddf(x) - sym_ddf(x)
+print('\n\n')
+print('Sympy vs Hand Derived Hessian check (should be almost zero)')
+print(ddf(x) - sym_ddf(x))
 
-print 'Sympy vs Ad Derive Hessian check (should be almost zero)'
-print adolc.hessian(0, numpy.ravel(x)).reshape(x.shape + x.shape) - sym_ddf(x)
+print('Sympy vs Ad Derive Hessian check (should be almost zero)')
+print(adolc.hessian(0, numpy.ravel(x)).reshape(x.shape + x.shape) - sym_ddf(x))
 
 
 

--- a/examples/explicit_euler.py
+++ b/examples/explicit_euler.py
@@ -66,4 +66,4 @@ xp1_plot = plot(ts, J[:,1], 'r')
 xp1_analytical_plot = plot(ts, phip1(ts,p,q), 'r.')
 
 show()
-print J
+print(J)

--- a/examples/qr_decomposition.py
+++ b/examples/qr_decomposition.py
@@ -28,16 +28,16 @@ Adot = V.reshape((N,N))
 Qdot = Z[:N**2,0,0].reshape((N,N))
 Rdot  = Z[N**2:,0,0].reshape((N,N))
 
-print dot(Qdot, R) + dot(Q, Rdot)
+print(dot(Qdot, R) + dot(Q, Rdot))
 
-print 'd=0: QR - A :\n', dot(Q, R) - A
-print 'd=1: QR - A :\n', dot(Qdot, R) + dot(Q, Rdot) - Adot
+print('d=0: QR - A :\n', dot(Q, R) - A)
+print('d=1: QR - A :\n', dot(Qdot, R) + dot(Q, Rdot) - Adot)
 
-print 'd=0: Q.T Q - I :\n', dot(Q.T, Q) - numpy.eye(N)
-print 'd=1: Q.T Q - I :\n', dot(Qdot.T, Q) + dot(Q.T,Qdot)
+print('d=0: Q.T Q - I :\n', dot(Q.T, Q) - numpy.eye(N))
+print('d=1: Q.T Q - I :\n', dot(Qdot.T, Q) + dot(Q.T,Qdot))
 
-print 'd=0: R - triu(R) :\n', R - numpy.triu(R)
-print 'd=1: R - triu(R) :\n', Rdot - numpy.triu(Rdot)
+print('d=0: R - triu(R) :\n', R - numpy.triu(R))
+print('d=1: R - triu(R) :\n', Rdot - numpy.triu(Rdot))
 
 
 

--- a/examples/sparse_jacobi_matrix.py
+++ b/examples/sparse_jacobi_matrix.py
@@ -33,9 +33,9 @@ options = numpy.array([0,0,0,0],dtype=int)
 pat = adolc.sparse.jac_pat(0,x,options)
 result = adolc.colpack.sparse_jac_no_repeat(0,x,options)
 
-print adolc.jacobian(0,x)
-print pat
+print(adolc.jacobian(0,x))
+print(pat)
 
-print result
+print(result)
 
 

--- a/examples/using_pyadolc_with_pyipopt.py
+++ b/examples/using_pyadolc_with_pyipopt.py
@@ -194,12 +194,12 @@ eval_h_adolc = Eval_h_adolc(x0)
 pat = eval_h(x0,  numpy.array([1.,2.]), 1., True)
 val = eval_h(x0,  numpy.array([1.,2.]), 1., False)
 H1 = scipy.sparse.coo_matrix( (val, (pat[0], pat[1])), shape=(4, 4))
-print 'symbolic Hessian=\n',H1
+print('symbolic Hessian=\n',H1)
 
 pat = eval_h_adolc(x0,  numpy.array([1.,2.]), 1., True)
 val = eval_h_adolc(x0,  numpy.array([1.,2.]), 1., False)
 H2 = scipy.sparse.coo_matrix( (val, (pat[0], pat[1])), shape=(4, 4))
-print 'pyadolc Hessian=\n',H2
+print('pyadolc Hessian=\n',H2)
 
 # function of f
 assert_almost_equal(eval_f(x0), eval_f_adolc(x0))
@@ -241,8 +241,8 @@ end_time = time.time()
 nlp_adolc.close()
 
 adolc_optimization_time = end_time - start_time
-print 'optimization time with derivatives computed by adolc = ', adolc_optimization_time
-print 'optimization time with derivatives computed by hand = ',pure_python_optimization_time
+print('optimization time with derivatives computed by adolc = ', adolc_optimization_time)
+print('optimization time with derivatives computed by hand = ',pure_python_optimization_time)
 
 # # this works with the pyipopt version from code.google.com
 # assert_array_almost_equal(result[0], result_adolc[0])

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,17 @@ if sys.platform == 'darwin' and os.environ.get('CC', 'clang').find('clang') > 0:
 
 include_dirs = [get_numpy_include_dirs()[0], boost_include_path, adolc_include_path, colpack_include_path]
 library_dirs = [boost_library_path1, boost_library_path2, adolc_library_path1, adolc_library_path2, colpack_lib_path1, colpack_lib_path2]
-libraries = ['boost_python','boost_numpy', 'adolc', 'ColPack']
+if sys.version_info.major<3:
+    boost_libraries = ['boost_python','boost_numpy']
+else:
+    boost_libraries = ['boost_python3','boost_numpy3']
+libraries = boost_libraries +['adolc', 'ColPack']
 
-print ''
-print '\033[1;31mPlease check that the following settings are correct for your system:\n\033[1;m'
-print 'include_dirs = %s\n'%str(include_dirs)
-print 'library_dirs = %s\n'%str(library_dirs)
-print '''
+print('')
+print('\033[1;31mPlease check that the following settings are correct for your system:\n\033[1;m')
+print('include_dirs = %s\n'%str(include_dirs))
+print('library_dirs = %s\n'%str(library_dirs))
+print('''
 If ADOL-C or Colpack cannot be found, you can manually set the paths via
 ``export ADOLC_DIR=/path/to/adol-c`` and ``export COLPACK_DIR=/path/to/colpack``
 
@@ -64,8 +68,12 @@ Example:
 
     CC=clang CXX=clang++ python setup.py
 
-'''
-raw_input("Press enter to build pyadolc.")
+''')
+if sys.version_info.major<3:
+    raw_input("Press enter to build pyadolc.")
+else:
+    input("Press enter to build pyadolc.")
+
 
 
 # PACKAGE INFORMATION
@@ -88,7 +96,7 @@ LONG_DESCRIPTION    = "\n".join(DOCLINES[2:])
 URL                 = "http://www.github.com/b45ch1/pyadolc"
 DOWNLOAD_URL        = "http://www.github.com/b45ch1/pyadolc"
 LICENSE             = 'BSD'
-CLASSIFIERS         = filter(None, CLASSIFIERS.split('\n'))
+CLASSIFIERS         = [_f for _f in CLASSIFIERS.split('\n') if _f]
 AUTHOR              = "Sebastian F. Walter"
 AUTHOR_EMAIL        = "sebastian.walter@gmail.com"
 PLATFORMS           = ["Linux"]
@@ -102,7 +110,7 @@ VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 # override default setup.py help output
 import sys
 if len(sys.argv) == 1:
-    print """
+    print("""
 
     \033[1;31mYou didn't enter what to do!\n\033[1;m
 
@@ -121,7 +129,7 @@ if len(sys.argv) == 1:
 
 
     Remark: This is an override of the default behaviour of the distutils setup.
-    """
+    """)
     exit()
 
 class clean(Command):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import inspect
 
 BASEDIR = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
-BOOST_DIR   = os.environ.get('BOOST_DIR', os.path.join(BASEDIR, '/usr/local'))
+BOOST_DIR   = os.environ.get('BOOST_DIR', os.path.join(BASEDIR, '/usr/include'))
 ADOLC_DIR   = os.environ.get('ADOLC_DIR', os.path.join(BASEDIR, 'PACKAGES/ADOL-C/inst'))
 COLPACK_DIR = os.environ.get('COLPACK_DIR', os.path.join(BASEDIR, 'PACKAGES/ADOL-C/ThirdParty/ColPack'))
 
@@ -44,7 +44,7 @@ if sys.platform == 'darwin' and os.environ.get('CC', 'clang').find('clang') > 0:
 
 include_dirs = [get_numpy_include_dirs()[0], boost_include_path, adolc_include_path, colpack_include_path]
 library_dirs = [boost_library_path1, boost_library_path2, adolc_library_path1, adolc_library_path2, colpack_lib_path1, colpack_lib_path2]
-libraries = ['boost_python','adolc', 'ColPack']
+libraries = ['boost_python','boost_numpy', 'adolc', 'ColPack']
 
 print ''
 print '\033[1;31mPlease check that the following settings are correct for your system:\n\033[1;m'

--- a/tests/basic_comparison_PyADOLC_ADOLC/main.py
+++ b/tests/basic_comparison_PyADOLC_ADOLC/main.py
@@ -19,8 +19,8 @@ y = adolc.function(13, x)
 g = adolc.gradient(13, x)
 J = adolc.jacobian(13, x)
 
-print 'function y=', y
-print 'gradient g=', g
-print 'Jacobian J=', J
+print('function y=', y)
+print('gradient g=', g)
+print('Jacobian J=', J)
 
 

--- a/tests/comparison_pycppad_pyadolc/compare_pycppad_pyadolc.py
+++ b/tests/comparison_pycppad_pyadolc/compare_pycppad_pyadolc.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
 	N_max = 120
 	reps = 100
 
-	Ns = range(2,N_max,5)
+	Ns = list(range(2,N_max,5))
 	adolc_gradient_runtimes = []
 	cppad_gradient_runtimes = []
 	adolc_hessian_runtimes = []

--- a/tests/experimental_tests.py
+++ b/tests/experimental_tests.py
@@ -30,8 +30,8 @@ def test_big_tape():
     dependent(ay)
     trace_off()
 
-    print tapestats(0)
-    print function(0,[1.])
+    print(tapestats(0))
+    print(function(0,[1.]))
     #tape_to_latex(0,numpy.array([1.]),numpy.array([0.]))
 
 
@@ -315,8 +315,8 @@ def test_ipopt_optimization():
     nlp_adolc.close()
     
     adolc_optimization_time = end_time - start_time
-    print 'optimization time with derivatives computed by adolc = ', adolc_optimization_time
-    print 'optimization time with derivatives computed by hand = ',pure_python_optimization_time
+    print('optimization time with derivatives computed by adolc = ', adolc_optimization_time)
+    print('optimization time with derivatives computed by hand = ',pure_python_optimization_time)
     assert adolc_optimization_time / pure_python_optimization_time < 10
     
     # this works with the pyipopt version from code.google.com
@@ -337,5 +337,5 @@ if __name__ == '__main__':
     try:
         import nose
     except:
-        print 'Please install nose for unit testing'
+        print('Please install nose for unit testing')
     nose.runmodule()

--- a/tests/known_bugs.py
+++ b/tests/known_bugs.py
@@ -6,19 +6,19 @@ class adouble:
     
     
     def __mul__(self, rhs):
-       print 'called __mul__'
+       print('called __mul__')
        if isinstance(rhs, adouble):
-           print 'case adouble'
+           print('case adouble')
            return adouble(self.x * rhs.x)
        elif numpy.isscalar(rhs):
-           print 'case scalar'
+           print('case scalar')
            return adouble(self.x * rhs)
        elif isinstance(rhs, numpy.ndarray):
-           print 'case ndarray'
+           print('case ndarray')
            return rhs * self
 
     def __rmul__(self, lhs):
-       print 'called __rmul__'
+       print('called __rmul__')
        return self * lhs
     
     def __str__(self):
@@ -27,7 +27,7 @@ class adouble:
     def __repr__(self):
        return str(self)
 
-print 'numpy.__version__=',numpy.__version__,'\n'
+print('numpy.__version__=',numpy.__version__,'\n')
 
 x  = numpy.ones(2,dtype=float)
 z = numpy.ones(2,dtype=float)
@@ -36,20 +36,20 @@ y = numpy.ones(2,dtype=object)
 
 a = adouble(2)
 
-print 'executing a *= x'
+print('executing a *= x')
 a *= x
-print a,' where expected [2.0a, 2.0a]\n'
+print(a,' where expected [2.0a, 2.0a]\n')
 
-print 'executing y *= a'
+print('executing y *= a')
 y *= a
-print y,' where expected [2.0a, 2.0a]\n'
+print(y,' where expected [2.0a, 2.0a]\n')
 
-print 'executing z = z * a'
+print('executing z = z * a')
 z = z * a
-print z,' where expected [2.0a, 2.0a]\n'
+print(z,' where expected [2.0a, 2.0a]\n')
 
-print 'executing x *= a'
+print('executing x *= a')
 x *= a
-print x,' where expected [2.0a, 2.0a]\n'
+print(x,' where expected [2.0a, 2.0a]\n')
 
 

--- a/tests/speed_comparison_PyADOLC_ADOLC/benchmark.py
+++ b/tests/speed_comparison_PyADOLC_ADOLC/benchmark.py
@@ -12,7 +12,7 @@ def matrix_vector_multiplication(x):
 
 
 def benchmark(f,N,M,message):
-	print message
+	print(message)
 	x = numpy.array([1./(i+1) for i in range(N)])
 	y = numpy.zeros(M)
 	ax = adouble(x)
@@ -25,31 +25,31 @@ def benchmark(f,N,M,message):
 	trace_off()
 	#tape_to_latex(1,x,y)
 
-	print 'N=%d,M=%d'%(N,M)
+	print('N=%d,M=%d'%(N,M))
 	
 	runtime_taping = time.time() - start_time
-	print 'PyADOLC\tfunction taping:\t........\telapsed time: %f'%runtime_taping
+	print('PyADOLC\tfunction taping:\t........\telapsed time: %f'%runtime_taping)
 
 	start_time = time.time()
 	y_adolc = function(1,x)
 	runtime_adolc = time.time() - start_time
-	print 'Adolc\tfunction evaluation:\t%f\telapsed time: %f'%(y_adolc[0],runtime_adolc)
+	print('Adolc\tfunction evaluation:\t%f\telapsed time: %f'%(y_adolc[0],runtime_adolc))
 	
 	start_time = time.time()
 	y_normal = f(x)
 	runtime_normal = time.time() - start_time
-	print 'normal\tfunction evaluation:\t%f\telapsed time: %f'%(y_normal[0],runtime_normal)
+	print('normal\tfunction evaluation:\t%f\telapsed time: %f'%(y_normal[0],runtime_normal))
 
 	start_time = time.time()
 	J = jacobian(1,x)
 	runtime_jacobian = time.time() - start_time
-	print 'jacobian evaluation:\t\t........\telapsed time: %f'%runtime_jacobian
+	print('jacobian evaluation:\t\t........\telapsed time: %f'%runtime_jacobian)
 
 	if M==1:
 		start_time = time.time()
 		g = gradient(1,x)
 		runtime_gradient = time.time() - start_time
-		print 'gradient evaluation:\t\t........\telapsed time: %f'%runtime_gradient
+		print('gradient evaluation:\t\t........\telapsed time: %f'%runtime_gradient)
 
 if __name__ == "__main__":
 	import sys

--- a/tests/speed_comparison_pyadolc_ScientificPythonFunctionsDerivatives/pyadolc_vs_scientific_python.py
+++ b/tests/speed_comparison_pyadolc_ScientificPythonFunctionsDerivatives/pyadolc_vs_scientific_python.py
@@ -24,15 +24,15 @@ start_time = time()
 adolc_H = hessian(0,x)
 end_time = time()
 adolc_runtime = (end_time-start_time)
-print 'adolc: elapsed time = %f sec' %adolc_runtime
+print('adolc: elapsed time = %f sec' %adolc_runtime)
 
 start_time = time()
 scientific_H = array(f(sx)[2])
 end_time = time()
 scientific_runtime = (end_time-start_time)
-print 'Scientific: elapsed time = %f sec' %scientific_runtime
+print('Scientific: elapsed time = %f sec' %scientific_runtime)
 
-print 'ratio time  adolc/Scientific Python:  %f'%(adolc_runtime/scientific_runtime)
+print('ratio time  adolc/Scientific Python:  %f'%(adolc_runtime/scientific_runtime))
 assert prod(scientific_H == adolc_H)
 
 

--- a/tests/utility_and_helper_functions_explained/utility.py
+++ b/tests/utility_and_helper_functions_explained/utility.py
@@ -8,10 +8,10 @@ def test_tape_to_latex():
 		a = avec[0]*avec[-1]
 		c =avec[0]*avec[0]
 		if isinstance(a,badouble):
-			print avec[0].loc
-			print avec[1].loc
-			print a.loc
-			print c.loc
+			print(avec[0].loc)
+			print(avec[1].loc)
+			print(a.loc)
+			print(c.loc)
 		return a
 
 
@@ -42,7 +42,7 @@ def test_tape_stats():
 	depends_on(ay)
 	trace_off()
 
-	print tapestats(1)
+	print(tapestats(1))
 
 if __name__ == "__main__":
 	test_tape_stats()


### PR DESCRIPTION
Hi!
I updated C++ code for compatibility with current Boost (v1.66), and Python code for compatibility with Python 3. 
Under Python 3, all tests except for one pass (test_float_tangent_float_tangent (adolc.tests.test_tangent.TangentOperationsTests fails probably because of difference between / and // operators). Under Python 2, all tests pass onmy computer.
Best regards,
Marek